### PR TITLE
Additions for multi-volume rendering in scenery

### DIFF
--- a/src/main/java/tpietzsch/example2/MultiVolumeShaderMip9.java
+++ b/src/main/java/tpietzsch/example2/MultiVolumeShaderMip9.java
@@ -1,7 +1,6 @@
 package tpietzsch.example2;
 
 import bdv.tools.brightness.ConverterSetup;
-import net.imglib2.display.ColorConverter;
 import net.imglib2.type.numeric.ARGBType;
 import org.joml.Matrix4f;
 import org.joml.Matrix4fc;
@@ -12,13 +11,7 @@ import tpietzsch.backend.Texture2D;
 import tpietzsch.cache.CacheSpec;
 import tpietzsch.cache.TextureCache;
 import tpietzsch.dither.DitherBuffer;
-import tpietzsch.shadergen.Uniform1f;
-import tpietzsch.shadergen.Uniform2f;
-import tpietzsch.shadergen.Uniform3f;
-import tpietzsch.shadergen.Uniform3fv;
-import tpietzsch.shadergen.Uniform4f;
-import tpietzsch.shadergen.UniformMatrix4f;
-import tpietzsch.shadergen.UniformSampler;
+import tpietzsch.shadergen.*;
 import tpietzsch.shadergen.generate.Segment;
 import tpietzsch.shadergen.generate.SegmentTemplate;
 import tpietzsch.shadergen.generate.SegmentedShader;
@@ -51,6 +44,8 @@ public class MultiVolumeShaderMip9
 	private final Uniform2f uniformDsp;
 
 	private int viewportWidth;
+
+	private String sceneDepthTextureName = "sceneDepth";
 
 	public MultiVolumeShaderMip9( final int numVolumes, final boolean useDepthTexture, final double degrade )
 	{
@@ -150,7 +145,12 @@ public class MultiVolumeShaderMip9
 		if ( !useDepthTexture )
 			throw new UnsupportedOperationException();
 
-		prog.getUniformSampler( "sceneDepth" ).set( depth );
+		prog.getUniformSampler( sceneDepthTextureName ).set( depth );
+	}
+
+	public void setDepthTextureName(String name)
+	{
+		sceneDepthTextureName = name;
 	}
 
 	public void setConverter( int index, ConverterSetup converter )
@@ -214,9 +214,17 @@ public class MultiVolumeShaderMip9
 		uniformViewportSize.set( width, height );
 	}
 
+	public void init( GpuContext context )
+	{
+		prog.use( context );
+		prog.setUniforms( context );
+	}
+
 	public void use( GpuContext context )
 	{
 		prog.use( context );
+		// TODO: Ask Tobi, is this necessary? SceneryContext needs it
+		prog.setUniforms( context );
 	}
 
 	public void bindSamplers( GpuContext context )

--- a/src/main/java/tpietzsch/example2/MultiVolumeShaderMip9.java
+++ b/src/main/java/tpietzsch/example2/MultiVolumeShaderMip9.java
@@ -1,6 +1,7 @@
 package tpietzsch.example2;
 
 import bdv.tools.brightness.ConverterSetup;
+import net.imglib2.display.ColorConverter;
 import net.imglib2.type.numeric.ARGBType;
 import org.joml.Matrix4f;
 import org.joml.Matrix4fc;
@@ -11,7 +12,13 @@ import tpietzsch.backend.Texture2D;
 import tpietzsch.cache.CacheSpec;
 import tpietzsch.cache.TextureCache;
 import tpietzsch.dither.DitherBuffer;
-import tpietzsch.shadergen.*;
+import tpietzsch.shadergen.Uniform1f;
+import tpietzsch.shadergen.Uniform2f;
+import tpietzsch.shadergen.Uniform3f;
+import tpietzsch.shadergen.Uniform3fv;
+import tpietzsch.shadergen.Uniform4f;
+import tpietzsch.shadergen.UniformMatrix4f;
+import tpietzsch.shadergen.UniformSampler;
 import tpietzsch.shadergen.generate.Segment;
 import tpietzsch.shadergen.generate.SegmentTemplate;
 import tpietzsch.shadergen.generate.SegmentedShader;
@@ -44,8 +51,6 @@ public class MultiVolumeShaderMip9
 	private final Uniform2f uniformDsp;
 
 	private int viewportWidth;
-
-	private String sceneDepthTextureName = "sceneDepth";
 
 	public MultiVolumeShaderMip9( final int numVolumes, final boolean useDepthTexture, final double degrade )
 	{
@@ -145,12 +150,7 @@ public class MultiVolumeShaderMip9
 		if ( !useDepthTexture )
 			throw new UnsupportedOperationException();
 
-		prog.getUniformSampler( sceneDepthTextureName ).set( depth );
-	}
-
-	public void setDepthTextureName(String name)
-	{
-		sceneDepthTextureName = name;
+		prog.getUniformSampler( "sceneDepth" ).set( depth );
 	}
 
 	public void setConverter( int index, ConverterSetup converter )
@@ -214,17 +214,9 @@ public class MultiVolumeShaderMip9
 		uniformViewportSize.set( width, height );
 	}
 
-	public void init( GpuContext context )
-	{
-		prog.use( context );
-		prog.setUniforms( context );
-	}
-
 	public void use( GpuContext context )
 	{
 		prog.use( context );
-		// TODO: Ask Tobi, is this necessary? SceneryContext needs it
-		prog.setUniforms( context );
 	}
 
 	public void bindSamplers( GpuContext context )

--- a/src/main/java/tpietzsch/example2/SceneryMultiVolumeShaderMip.java
+++ b/src/main/java/tpietzsch/example2/SceneryMultiVolumeShaderMip.java
@@ -19,99 +19,105 @@ import tpietzsch.shadergen.generate.SegmentedShaderBuilder;
 
 public class SceneryMultiVolumeShaderMip
 {
-    private static final int NUM_BLOCK_SCALES = 10;
+	private static final int NUM_BLOCK_SCALES = 10;
 
-    private final int numVolumes;
+	private final int numVolumes;
 
-    private final boolean useDepthTexture;
+	private final boolean useDepthTexture;
 
-    // step size on near plane = pixel_width
-    // step size on far plane = degrade * pixel_width
-    private final double degrade;
+	// step size on near plane = pixel_width
+	// step size on far plane = degrade * pixel_width
+	private final double degrade;
 
-    private final SegmentedShader prog;
-    private final VolumeSegment[] volumeSegments;
-    private final ConverterSegment[] converterSegments;
+	private final SegmentedShader prog;
 
-    private final UniformMatrix4f uniformIpv;
-    private final Uniform2f uniformViewportSize;
+	private final VolumeSegment[] volumeSegments;
 
-    private final Uniform1f uniformNw;
-    private final Uniform1f uniformFwnw;
-    private final Uniform1f uniformXf;
+	private final ConverterSegment[] converterSegments;
 
-    private final UniformMatrix4f uniformTransform;
-    private final Uniform2f uniformDsp;
+	private final UniformMatrix4f uniformIpv;
 
-    private int viewportWidth;
+	private final Uniform2f uniformViewportSize;
 
-    private String sceneDepthTextureName = "sceneDepth";
+	private final Uniform1f uniformNw;
 
-    public SceneryMultiVolumeShaderMip( final int numVolumes, final boolean useDepthTexture, final double degrade )
-    {
-        this.numVolumes = numVolumes;
-        this.useDepthTexture = useDepthTexture;
-        this.degrade = degrade;
+	private final Uniform1f uniformFwnw;
 
-        final SegmentedShaderBuilder builder = new SegmentedShaderBuilder();
-        final Segment vp = new SegmentTemplate("SceneryMultiVolume.vert" ).instantiate();
-        builder.vertex( vp );
+	private final Uniform1f uniformXf;
 
-        final SegmentTemplate templateIntersectBox = new SegmentTemplate(
-                "intersectbox.fp" );
-        builder.fragment( templateIntersectBox.instantiate() );
-        final SegmentTemplate templateBlkVol = new SegmentTemplate(
-                "blkvol.fp",
-                "im", "sourcemin", "sourcemax", "intersectBoundingBox",
-                "lutSampler", "blockScales", "lutScale", "lutOffset", "blockTexture" );
-        final SegmentTemplate templateColConv = new SegmentTemplate(
-                "colconv.fp",
-                "convert", "offset", "scale" );
-        final SegmentTemplate templateMaxDepth = new SegmentTemplate(
-                useDepthTexture ? "maxdepthtexture_scenery.fp" : "maxdepthone.fp" );
-        builder.fragment( templateMaxDepth.instantiate() );
-        final SegmentTemplate templateFp = new SegmentTemplate(
-                "SceneryMultiVolume.frag",
-                "intersectBoundingBox", "blockTexture", "convert", "vis" );
-        final Segment fp = templateFp.instantiate();
-        fp.repeat( "vis", numVolumes );
-        final Segment blkVols[] = new Segment[ numVolumes ];
-        final Segment colConvs[] = new Segment[ numVolumes ];
-        for ( int i = 0; i < numVolumes; ++i )
-        {
-            final Segment blkVol = templateBlkVol.instantiate();
-            builder.fragment( blkVol );
-            fp.bind( "intersectBoundingBox", i, blkVol, "intersectBoundingBox" );
-            fp.bind( "blockTexture", i, blkVol, "blockTexture" );
-            blkVols[ i ] = blkVol;
+	private final UniformMatrix4f uniformTransform;
 
-            final Segment colConv = templateColConv.instantiate();
-            builder.fragment( colConv );
-            fp.bind( "convert", i, colConv, "convert" );
-            colConvs[ i ] = colConv;
-        }
-        builder.fragment( fp );
-        prog = builder.build();
+	private final Uniform2f uniformDsp;
 
-        uniformIpv = prog.getUniformMatrix4f( "ipv" );
-        uniformViewportSize = prog.getUniform2f( "viewportSize" );
-        uniformNw = prog.getUniform1f( "nw" );
-        uniformFwnw = prog.getUniform1f( "fwnw" );
-        uniformXf = prog.getUniform1f( "xf" );
+	private int viewportWidth;
 
-        volumeSegments = new VolumeSegment[ numVolumes ];
-        converterSegments = new ConverterSegment[ numVolumes ];
-        for ( int i = 0; i < numVolumes; ++i )
-        {
-            volumeSegments[ i ] = new VolumeSegment( prog, blkVols[ i ] );
-            converterSegments[ i ] = new ConverterSegment( prog, colConvs[ i ] );
-        }
+	private String sceneDepthTextureName = "sceneDepth";
 
-        uniformTransform = prog.getUniformMatrix4f( "transform" );
-        uniformDsp = prog.getUniform2f( "dsp" );
+	public SceneryMultiVolumeShaderMip( final int numVolumes, final boolean useDepthTexture, final double degrade )
+	{
+		this.numVolumes = numVolumes;
+		this.useDepthTexture = useDepthTexture;
+		this.degrade = degrade;
 
-        uniformTransform.set( new Matrix4f() );
-        uniformDsp.set( new Vector2f() );
+		final SegmentedShaderBuilder builder = new SegmentedShaderBuilder();
+		final Segment vp = new SegmentTemplate( "SceneryMultiVolume.vert" ).instantiate();
+		builder.vertex( vp );
+
+		final SegmentTemplate templateIntersectBox = new SegmentTemplate(
+				"intersectbox.fp" );
+		builder.fragment( templateIntersectBox.instantiate() );
+		final SegmentTemplate templateBlkVol = new SegmentTemplate(
+				"blkvol.fp",
+				"im", "sourcemin", "sourcemax", "intersectBoundingBox",
+				"lutSampler", "blockScales", "lutScale", "lutOffset", "blockTexture" );
+		final SegmentTemplate templateColConv = new SegmentTemplate(
+				"colconv.fp",
+				"convert", "offset", "scale" );
+		final SegmentTemplate templateMaxDepth = new SegmentTemplate(
+				useDepthTexture ? "maxdepthtexture_scenery.fp" : "maxdepthone.fp" );
+		builder.fragment( templateMaxDepth.instantiate() );
+		final SegmentTemplate templateFp = new SegmentTemplate(
+				"SceneryMultiVolume.frag",
+				"intersectBoundingBox", "blockTexture", "convert", "vis" );
+		final Segment fp = templateFp.instantiate();
+		fp.repeat( "vis", numVolumes );
+		final Segment blkVols[] = new Segment[ numVolumes ];
+		final Segment colConvs[] = new Segment[ numVolumes ];
+		for ( int i = 0; i < numVolumes; ++i )
+		{
+			final Segment blkVol = templateBlkVol.instantiate();
+			builder.fragment( blkVol );
+			fp.bind( "intersectBoundingBox", i, blkVol, "intersectBoundingBox" );
+			fp.bind( "blockTexture", i, blkVol, "blockTexture" );
+			blkVols[ i ] = blkVol;
+
+			final Segment colConv = templateColConv.instantiate();
+			builder.fragment( colConv );
+			fp.bind( "convert", i, colConv, "convert" );
+			colConvs[ i ] = colConv;
+		}
+		builder.fragment( fp );
+		prog = builder.build();
+
+		uniformIpv = prog.getUniformMatrix4f( "ipv" );
+		uniformViewportSize = prog.getUniform2f( "viewportSize" );
+		uniformNw = prog.getUniform1f( "nw" );
+		uniformFwnw = prog.getUniform1f( "fwnw" );
+		uniformXf = prog.getUniform1f( "xf" );
+
+		volumeSegments = new VolumeSegment[ numVolumes ];
+		converterSegments = new ConverterSegment[ numVolumes ];
+		for ( int i = 0; i < numVolumes; ++i )
+		{
+			volumeSegments[ i ] = new VolumeSegment( prog, blkVols[ i ] );
+			converterSegments[ i ] = new ConverterSegment( prog, colConvs[ i ] );
+		}
+
+		uniformTransform = prog.getUniformMatrix4f( "transform" );
+		uniformDsp = prog.getUniform2f( "dsp" );
+
+		uniformTransform.set( new Matrix4f() );
+		uniformDsp.set( new Vector2f() );
 
 //		final StringBuilder vertexShaderCode = prog.getVertexShaderCode();
 //		System.out.println( "vertexShaderCode = " + vertexShaderCode );
@@ -119,193 +125,200 @@ public class SceneryMultiVolumeShaderMip
 //		final StringBuilder fragmentShaderCode = prog.getFragmentShaderCode();
 //		System.out.println( "fragmentShaderCode = " + fragmentShaderCode );
 //		System.out.println( "\n\n--------------------------------\n\n" );
-    }
+	}
 
-    public int getNumVolumes()
-    {
-        return numVolumes;
-    }
+	public int getNumVolumes()
+	{
+		return numVolumes;
+	}
 
-    public void setTextureCache( TextureCache textureCache )
-    {
-        CacheSpec spec = textureCache.spec();
-        final int[] bs = spec.blockSize();
-        final int[] pbs = spec.paddedBlockSize();
-        final int[] bo = spec.padOffset();
-        prog.getUniform3f( "blockSize" ).set( bs[ 0 ], bs[ 1 ], bs[ 2 ] );
-        prog.getUniform3f( "paddedBlockSize" ).set( pbs[ 0 ], pbs[ 1 ], pbs[ 2 ] );
-        prog.getUniform3f( "cachePadOffset" ).set( bo[ 0 ], bo[ 1 ], bo[ 2 ] );
+	public void setTextureCache( TextureCache textureCache )
+	{
+		CacheSpec spec = textureCache.spec();
+		final int[] bs = spec.blockSize();
+		final int[] pbs = spec.paddedBlockSize();
+		final int[] bo = spec.padOffset();
+		prog.getUniform3f( "blockSize" ).set( bs[ 0 ], bs[ 1 ], bs[ 2 ] );
+		prog.getUniform3f( "paddedBlockSize" ).set( pbs[ 0 ], pbs[ 1 ], pbs[ 2 ] );
+		prog.getUniform3f( "cachePadOffset" ).set( bo[ 0 ], bo[ 1 ], bo[ 2 ] );
 
-        prog.getUniformSampler( "volumeCache" ).set( textureCache );
-        prog.getUniform3f( "cacheSize" ).set( textureCache.texWidth(), textureCache.texHeight(), textureCache.texDepth() );
-    }
+		prog.getUniformSampler( "volumeCache" ).set( textureCache );
+		prog.getUniform3f( "cacheSize" ).set( textureCache.texWidth(), textureCache.texHeight(), textureCache.texDepth() );
+	}
 
-    public void setDepthTexture( Texture2D depth )
-    {
-        if ( !useDepthTexture )
-            throw new UnsupportedOperationException();
+	public void setDepthTexture( Texture2D depth )
+	{
+		if ( !useDepthTexture )
+			throw new UnsupportedOperationException();
 
-        prog.getUniformSampler( sceneDepthTextureName ).set( depth );
-    }
+		prog.getUniformSampler( sceneDepthTextureName ).set( depth );
+	}
 
-    public void setDepthTextureName(String name)
-    {
-        sceneDepthTextureName = name;
-    }
+	public void setDepthTextureName( String name )
+	{
+		sceneDepthTextureName = name;
+	}
 
-    public void setConverter( int index, ConverterSetup converter )
-    {
-        converterSegments[ index ].setData( converter );
-    }
+	public void setConverter( int index, ConverterSetup converter )
+	{
+		converterSegments[ index ].setData( converter );
+	}
 
-    public void setVolume( int index, VolumeBlocks volume )
-    {
-        volumeSegments[ index ].setData( volume );
-    }
+	public void setVolume( int index, VolumeBlocks volume )
+	{
+		volumeSegments[ index ].setData( volume );
+	}
 
-    public void setDither( DitherBuffer dither, int step )
-    {
-        uniformViewportSize.set( dither.effectiveViewportWidth(), dither.effectiveViewportHeight() );
-        uniformTransform.set( dither.ndcTransform( step ) );
-        uniformDsp.set( dither.fragShift( step ) );
-    }
+	public void setDither( DitherBuffer dither, int step )
+	{
+		uniformViewportSize.set( dither.effectiveViewportWidth(), dither.effectiveViewportHeight() );
+		uniformTransform.set( dither.ndcTransform( step ) );
+		uniformDsp.set( dither.fragShift( step ) );
+	}
 
-    /**
-     * @param minWorldVoxelSize pass {@code 0} if unknown.
-     */
-    public void setProjectionViewMatrix( final Matrix4fc pv, final double minWorldVoxelSize )
-    {
-        final Matrix4f ipv = pv.invert( new Matrix4f() );
-        final float dx = ( float ) ( 2.0 / viewportWidth );
+	/**
+	 * @param minWorldVoxelSize pass {@code 0} if unknown.
+	 */
+	public void setProjectionViewMatrix( final Matrix4fc pv, final double minWorldVoxelSize )
+	{
+		final Matrix4f ipv = pv.invert( new Matrix4f() );
+		final float dx = ( float ) ( 2.0 / viewportWidth );
 
-        final Vector4f a = ipv.transform( new Vector4f( 0, 0, -1, 1 ) );
-        final Vector4f c = ipv.transform( new Vector4f( 0, 0,  1, 1 ) );
-        final Vector4f b = ipv.transform( new Vector4f( 0, 0,  0, 1 ) );
-        final Vector4f adx = ipv.transform( new Vector4f( dx, 0, -1, 1 ) );
-        final Vector4f cdx = ipv.transform( new Vector4f( dx, 0,  1, 1 ) );
-        a.div( a.w() );
-        b.div( b.w() );
-        c.div( c.w() );
-        adx.div( adx.w() );
-        cdx.div( cdx.w() );
+		final Vector4f a = ipv.transform( new Vector4f( 0, 0, -1, 1 ) );
+		final Vector4f c = ipv.transform( new Vector4f( 0, 0, 1, 1 ) );
+		final Vector4f b = ipv.transform( new Vector4f( 0, 0, 0, 1 ) );
+		final Vector4f adx = ipv.transform( new Vector4f( dx, 0, -1, 1 ) );
+		final Vector4f cdx = ipv.transform( new Vector4f( dx, 0, 1, 1 ) );
+		a.div( a.w() );
+		b.div( b.w() );
+		c.div( c.w() );
+		adx.div( adx.w() );
+		cdx.div( cdx.w() );
 
-        final double sNear = Math.max( adx.sub( a ).length(), minWorldVoxelSize );
-        final double sFar = Math.max( cdx.sub( c ).length(), minWorldVoxelSize );
-        final double ac = c.sub( a ).length();
-        final double scale = 1.0 / ac;
-        final double nw = sNear * scale;
-        final double fw = degrade * sFar * scale;
-        final double ab = b.sub( a, new Vector4f() ).length();
-        final double f = ab / ac;
+		final double sNear = Math.max( adx.sub( a ).length(), minWorldVoxelSize );
+		final double sFar = Math.max( cdx.sub( c ).length(), minWorldVoxelSize );
+		final double ac = c.sub( a ).length();
+		final double scale = 1.0 / ac;
+		final double nw = sNear * scale;
+		final double fw = degrade * sFar * scale;
+		final double ab = b.sub( a, new Vector4f() ).length();
+		final double f = ab / ac;
 
-        uniformIpv.set( ipv );
-        uniformNw.set( ( float ) nw );
-        uniformFwnw.set( ( float ) ( fw - nw ) );
-        uniformXf.set( ( float ) f );
-    }
+		uniformIpv.set( ipv );
+		uniformNw.set( ( float ) nw );
+		uniformFwnw.set( ( float ) ( fw - nw ) );
+		uniformXf.set( ( float ) f );
+	}
 
-    public void setViewportWidth( int width )
-    {
-        viewportWidth = width;
-    }
+	public void setViewportWidth( int width )
+	{
+		viewportWidth = width;
+	}
 
-    public void setEffectiveViewportSize( int width, int height )
-    {
-        uniformViewportSize.set( width, height );
-    }
+	public void setEffectiveViewportSize( int width, int height )
+	{
+		uniformViewportSize.set( width, height );
+	}
 
-    public void init( GpuContext context )
-    {
-        prog.use( context );
-        prog.setUniforms( context );
-    }
+	public void init( GpuContext context )
+	{
+		prog.use( context );
+		prog.setUniforms( context );
+	}
 
-    public void use( GpuContext context )
-    {
-        prog.use( context );
-        // TODO: Ask Tobi, is this necessary? SceneryContext needs it
-        prog.setUniforms( context );
-    }
+	public void use( GpuContext context )
+	{
+		prog.use( context );
+		// TODO: Ask Tobi, is this necessary? SceneryContext needs it
+		prog.setUniforms( context );
+	}
 
-    public void bindSamplers( GpuContext context )
-    {
-        prog.bindSamplers( context );
-    }
+	public void bindSamplers( GpuContext context )
+	{
+		prog.bindSamplers( context );
+	}
 
-    public void setUniforms( GpuContext context )
-    {
-        prog.setUniforms( context );
-    }
+	public void setUniforms( GpuContext context )
+	{
+		prog.setUniforms( context );
+	}
 
-    static class ConverterSegment
-    {
-        private final Uniform4f uniformOffset;
-        private final Uniform4f uniformScale;
+	static class ConverterSegment
+	{
+		private final Uniform4f uniformOffset;
 
-        public ConverterSegment( final SegmentedShader prog, final Segment segment )
-        {
-            uniformOffset = prog.getUniform4f( segment,"offset" );
-            uniformScale = prog.getUniform4f( segment,"scale" );
-        }
+		private final Uniform4f uniformScale;
 
-        public void setData( ConverterSetup converter )
-        {
-            final double fmin = converter.getDisplayRangeMin() / 0xffff;
-            final double fmax = converter.getDisplayRangeMax() / 0xffff;
-            final double s = 1.0 / ( fmax - fmin );
-            final double o = -fmin * s;
+		public ConverterSegment( final SegmentedShader prog, final Segment segment )
+		{
+			uniformOffset = prog.getUniform4f( segment, "offset" );
+			uniformScale = prog.getUniform4f( segment, "scale" );
+		}
 
-            final int color = converter.getColor().get();
-            final double r = ( double ) ARGBType.red( color ) / 255.0;
-            final double g = ( double ) ARGBType.green( color ) / 255.0;
-            final double b = ( double ) ARGBType.blue( color ) / 255.0;
+		public void setData( ConverterSetup converter )
+		{
+			final double fmin = converter.getDisplayRangeMin() / 0xffff;
+			final double fmax = converter.getDisplayRangeMax() / 0xffff;
+			final double s = 1.0 / ( fmax - fmin );
+			final double o = -fmin * s;
+
+			final int color = converter.getColor().get();
+			final double r = ( double ) ARGBType.red( color ) / 255.0;
+			final double g = ( double ) ARGBType.green( color ) / 255.0;
+			final double b = ( double ) ARGBType.blue( color ) / 255.0;
 
 //			final double l = 0.2126 * r + 0.7152 * g + 0.0722 * b;
 //			final double l = 0.299 * r + 0.587 * g + 0.114 * b;
 
-            uniformOffset.set(
-                    ( float ) ( o * r ),
-                    ( float ) ( o * g ),
-                    ( float ) ( o * b ),
-                    ( float ) ( o ) );
-            uniformScale.set(
-                    ( float ) ( s * r ),
-                    ( float ) ( s * g ),
-                    ( float ) ( s * b ),
-                    ( float ) ( s ) );
-        }
-    }
+			uniformOffset.set(
+					( float ) ( o * r ),
+					( float ) ( o * g ),
+					( float ) ( o * b ),
+					( float ) ( o ) );
+			uniformScale.set(
+					( float ) ( s * r ),
+					( float ) ( s * g ),
+					( float ) ( s * b ),
+					( float ) ( s ) );
+		}
+	}
 
-    static class VolumeSegment
-    {
-        private final Uniform3fv uniformBlockScales;
-        private final UniformSampler uniformLutSampler;
-        private final Uniform3f uniformLutScale;
-        private final Uniform3f uniformLutOffset;
-        private final UniformMatrix4f uniformIm;
-        private final Uniform3f uniformSourcemin;
-        private final Uniform3f uniformSourcemax;
+	static class VolumeSegment
+	{
+		private final Uniform3fv uniformBlockScales;
 
-        public VolumeSegment( final SegmentedShader prog, final Segment volume )
-        {
-            uniformBlockScales = prog.getUniform3fv( volume, "blockScales" );
-            uniformLutSampler = prog.getUniformSampler( volume,"lutSampler" );
-            uniformLutScale = prog.getUniform3f( volume, "lutScale" );
-            uniformLutOffset = prog.getUniform3f( volume, "lutOffset" );
-            uniformIm = prog.getUniformMatrix4f( volume, "im" );
-            uniformSourcemin = prog.getUniform3f( volume,"sourcemin" );
-            uniformSourcemax = prog.getUniform3f( volume,"sourcemax" );
-        }
+		private final UniformSampler uniformLutSampler;
 
-        public void setData( VolumeBlocks blocks )
-        {
-            uniformBlockScales.set( blocks.getLutBlockScales( NUM_BLOCK_SCALES ) );
-            uniformLutSampler.set( blocks.getLookupTexture() );
-            uniformLutScale.set( blocks.getLutScale() );
-            uniformLutOffset.set( blocks.getLutOffset() );
-            uniformIm.set( blocks.getIms() );
-            uniformSourcemin.set( blocks.getSourceLevelMin() );
-            uniformSourcemax.set( blocks.getSourceLevelMax() );
-        }
-    }
+		private final Uniform3f uniformLutScale;
+
+		private final Uniform3f uniformLutOffset;
+
+		private final UniformMatrix4f uniformIm;
+
+		private final Uniform3f uniformSourcemin;
+
+		private final Uniform3f uniformSourcemax;
+
+		public VolumeSegment( final SegmentedShader prog, final Segment volume )
+		{
+			uniformBlockScales = prog.getUniform3fv( volume, "blockScales" );
+			uniformLutSampler = prog.getUniformSampler( volume, "lutSampler" );
+			uniformLutScale = prog.getUniform3f( volume, "lutScale" );
+			uniformLutOffset = prog.getUniform3f( volume, "lutOffset" );
+			uniformIm = prog.getUniformMatrix4f( volume, "im" );
+			uniformSourcemin = prog.getUniform3f( volume, "sourcemin" );
+			uniformSourcemax = prog.getUniform3f( volume, "sourcemax" );
+		}
+
+		public void setData( VolumeBlocks blocks )
+		{
+			uniformBlockScales.set( blocks.getLutBlockScales( NUM_BLOCK_SCALES ) );
+			uniformLutSampler.set( blocks.getLookupTexture() );
+			uniformLutScale.set( blocks.getLutScale() );
+			uniformLutOffset.set( blocks.getLutOffset() );
+			uniformIm.set( blocks.getIms() );
+			uniformSourcemin.set( blocks.getSourceLevelMin() );
+			uniformSourcemax.set( blocks.getSourceLevelMax() );
+		}
+	}
 }

--- a/src/main/java/tpietzsch/example2/SceneryMultiVolumeShaderMip.java
+++ b/src/main/java/tpietzsch/example2/SceneryMultiVolumeShaderMip.java
@@ -54,7 +54,7 @@ public class SceneryMultiVolumeShaderMip
         this.degrade = degrade;
 
         final SegmentedShaderBuilder builder = new SegmentedShaderBuilder();
-        final Segment vp = new SegmentTemplate("ex8vol.vp" ).instantiate();
+        final Segment vp = new SegmentTemplate("SceneryMultiVolume.vert" ).instantiate();
         builder.vertex( vp );
 
         final SegmentTemplate templateIntersectBox = new SegmentTemplate(
@@ -71,7 +71,7 @@ public class SceneryMultiVolumeShaderMip
                 useDepthTexture ? "maxdepthtexture_scenery.fp" : "maxdepthone.fp" );
         builder.fragment( templateMaxDepth.instantiate() );
         final SegmentTemplate templateFp = new SegmentTemplate(
-                "ex8vol.fp",
+                "SceneryMultiVolume.frag",
                 "intersectBoundingBox", "blockTexture", "convert", "vis" );
         final Segment fp = templateFp.instantiate();
         fp.repeat( "vis", numVolumes );

--- a/src/main/java/tpietzsch/example2/SceneryMultiVolumeShaderMip.java
+++ b/src/main/java/tpietzsch/example2/SceneryMultiVolumeShaderMip.java
@@ -1,0 +1,311 @@
+package tpietzsch.example2;
+
+import bdv.tools.brightness.ConverterSetup;
+import net.imglib2.type.numeric.ARGBType;
+import org.joml.Matrix4f;
+import org.joml.Matrix4fc;
+import org.joml.Vector2f;
+import org.joml.Vector4f;
+import tpietzsch.backend.GpuContext;
+import tpietzsch.backend.Texture2D;
+import tpietzsch.cache.CacheSpec;
+import tpietzsch.cache.TextureCache;
+import tpietzsch.dither.DitherBuffer;
+import tpietzsch.shadergen.*;
+import tpietzsch.shadergen.generate.Segment;
+import tpietzsch.shadergen.generate.SegmentTemplate;
+import tpietzsch.shadergen.generate.SegmentedShader;
+import tpietzsch.shadergen.generate.SegmentedShaderBuilder;
+
+public class SceneryMultiVolumeShaderMip
+{
+    private static final int NUM_BLOCK_SCALES = 10;
+
+    private final int numVolumes;
+
+    private final boolean useDepthTexture;
+
+    // step size on near plane = pixel_width
+    // step size on far plane = degrade * pixel_width
+    private final double degrade;
+
+    private final SegmentedShader prog;
+    private final VolumeSegment[] volumeSegments;
+    private final ConverterSegment[] converterSegments;
+
+    private final UniformMatrix4f uniformIpv;
+    private final Uniform2f uniformViewportSize;
+
+    private final Uniform1f uniformNw;
+    private final Uniform1f uniformFwnw;
+    private final Uniform1f uniformXf;
+
+    private final UniformMatrix4f uniformTransform;
+    private final Uniform2f uniformDsp;
+
+    private int viewportWidth;
+
+    private String sceneDepthTextureName = "sceneDepth";
+
+    public SceneryMultiVolumeShaderMip( final int numVolumes, final boolean useDepthTexture, final double degrade )
+    {
+        this.numVolumes = numVolumes;
+        this.useDepthTexture = useDepthTexture;
+        this.degrade = degrade;
+
+        final SegmentedShaderBuilder builder = new SegmentedShaderBuilder();
+        final Segment vp = new SegmentTemplate("ex8vol.vp" ).instantiate();
+        builder.vertex( vp );
+
+        final SegmentTemplate templateIntersectBox = new SegmentTemplate(
+                "intersectbox.fp" );
+        builder.fragment( templateIntersectBox.instantiate() );
+        final SegmentTemplate templateBlkVol = new SegmentTemplate(
+                "blkvol.fp",
+                "im", "sourcemin", "sourcemax", "intersectBoundingBox",
+                "lutSampler", "blockScales", "lutScale", "lutOffset", "blockTexture" );
+        final SegmentTemplate templateColConv = new SegmentTemplate(
+                "colconv.fp",
+                "convert", "offset", "scale" );
+        final SegmentTemplate templateMaxDepth = new SegmentTemplate(
+                useDepthTexture ? "maxdepthtexture_scenery.fp" : "maxdepthone.fp" );
+        builder.fragment( templateMaxDepth.instantiate() );
+        final SegmentTemplate templateFp = new SegmentTemplate(
+                "ex8vol.fp",
+                "intersectBoundingBox", "blockTexture", "convert", "vis" );
+        final Segment fp = templateFp.instantiate();
+        fp.repeat( "vis", numVolumes );
+        final Segment blkVols[] = new Segment[ numVolumes ];
+        final Segment colConvs[] = new Segment[ numVolumes ];
+        for ( int i = 0; i < numVolumes; ++i )
+        {
+            final Segment blkVol = templateBlkVol.instantiate();
+            builder.fragment( blkVol );
+            fp.bind( "intersectBoundingBox", i, blkVol, "intersectBoundingBox" );
+            fp.bind( "blockTexture", i, blkVol, "blockTexture" );
+            blkVols[ i ] = blkVol;
+
+            final Segment colConv = templateColConv.instantiate();
+            builder.fragment( colConv );
+            fp.bind( "convert", i, colConv, "convert" );
+            colConvs[ i ] = colConv;
+        }
+        builder.fragment( fp );
+        prog = builder.build();
+
+        uniformIpv = prog.getUniformMatrix4f( "ipv" );
+        uniformViewportSize = prog.getUniform2f( "viewportSize" );
+        uniformNw = prog.getUniform1f( "nw" );
+        uniformFwnw = prog.getUniform1f( "fwnw" );
+        uniformXf = prog.getUniform1f( "xf" );
+
+        volumeSegments = new VolumeSegment[ numVolumes ];
+        converterSegments = new ConverterSegment[ numVolumes ];
+        for ( int i = 0; i < numVolumes; ++i )
+        {
+            volumeSegments[ i ] = new VolumeSegment( prog, blkVols[ i ] );
+            converterSegments[ i ] = new ConverterSegment( prog, colConvs[ i ] );
+        }
+
+        uniformTransform = prog.getUniformMatrix4f( "transform" );
+        uniformDsp = prog.getUniform2f( "dsp" );
+
+        uniformTransform.set( new Matrix4f() );
+        uniformDsp.set( new Vector2f() );
+
+//		final StringBuilder vertexShaderCode = prog.getVertexShaderCode();
+//		System.out.println( "vertexShaderCode = " + vertexShaderCode );
+//		System.out.println( "\n\n--------------------------------\n\n" );
+//		final StringBuilder fragmentShaderCode = prog.getFragmentShaderCode();
+//		System.out.println( "fragmentShaderCode = " + fragmentShaderCode );
+//		System.out.println( "\n\n--------------------------------\n\n" );
+    }
+
+    public int getNumVolumes()
+    {
+        return numVolumes;
+    }
+
+    public void setTextureCache( TextureCache textureCache )
+    {
+        CacheSpec spec = textureCache.spec();
+        final int[] bs = spec.blockSize();
+        final int[] pbs = spec.paddedBlockSize();
+        final int[] bo = spec.padOffset();
+        prog.getUniform3f( "blockSize" ).set( bs[ 0 ], bs[ 1 ], bs[ 2 ] );
+        prog.getUniform3f( "paddedBlockSize" ).set( pbs[ 0 ], pbs[ 1 ], pbs[ 2 ] );
+        prog.getUniform3f( "cachePadOffset" ).set( bo[ 0 ], bo[ 1 ], bo[ 2 ] );
+
+        prog.getUniformSampler( "volumeCache" ).set( textureCache );
+        prog.getUniform3f( "cacheSize" ).set( textureCache.texWidth(), textureCache.texHeight(), textureCache.texDepth() );
+    }
+
+    public void setDepthTexture( Texture2D depth )
+    {
+        if ( !useDepthTexture )
+            throw new UnsupportedOperationException();
+
+        prog.getUniformSampler( sceneDepthTextureName ).set( depth );
+    }
+
+    public void setDepthTextureName(String name)
+    {
+        sceneDepthTextureName = name;
+    }
+
+    public void setConverter( int index, ConverterSetup converter )
+    {
+        converterSegments[ index ].setData( converter );
+    }
+
+    public void setVolume( int index, VolumeBlocks volume )
+    {
+        volumeSegments[ index ].setData( volume );
+    }
+
+    public void setDither( DitherBuffer dither, int step )
+    {
+        uniformViewportSize.set( dither.effectiveViewportWidth(), dither.effectiveViewportHeight() );
+        uniformTransform.set( dither.ndcTransform( step ) );
+        uniformDsp.set( dither.fragShift( step ) );
+    }
+
+    /**
+     * @param minWorldVoxelSize pass {@code 0} if unknown.
+     */
+    public void setProjectionViewMatrix( final Matrix4fc pv, final double minWorldVoxelSize )
+    {
+        final Matrix4f ipv = pv.invert( new Matrix4f() );
+        final float dx = ( float ) ( 2.0 / viewportWidth );
+
+        final Vector4f a = ipv.transform( new Vector4f( 0, 0, -1, 1 ) );
+        final Vector4f c = ipv.transform( new Vector4f( 0, 0,  1, 1 ) );
+        final Vector4f b = ipv.transform( new Vector4f( 0, 0,  0, 1 ) );
+        final Vector4f adx = ipv.transform( new Vector4f( dx, 0, -1, 1 ) );
+        final Vector4f cdx = ipv.transform( new Vector4f( dx, 0,  1, 1 ) );
+        a.div( a.w() );
+        b.div( b.w() );
+        c.div( c.w() );
+        adx.div( adx.w() );
+        cdx.div( cdx.w() );
+
+        final double sNear = Math.max( adx.sub( a ).length(), minWorldVoxelSize );
+        final double sFar = Math.max( cdx.sub( c ).length(), minWorldVoxelSize );
+        final double ac = c.sub( a ).length();
+        final double scale = 1.0 / ac;
+        final double nw = sNear * scale;
+        final double fw = degrade * sFar * scale;
+        final double ab = b.sub( a, new Vector4f() ).length();
+        final double f = ab / ac;
+
+        uniformIpv.set( ipv );
+        uniformNw.set( ( float ) nw );
+        uniformFwnw.set( ( float ) ( fw - nw ) );
+        uniformXf.set( ( float ) f );
+    }
+
+    public void setViewportWidth( int width )
+    {
+        viewportWidth = width;
+    }
+
+    public void setEffectiveViewportSize( int width, int height )
+    {
+        uniformViewportSize.set( width, height );
+    }
+
+    public void init( GpuContext context )
+    {
+        prog.use( context );
+        prog.setUniforms( context );
+    }
+
+    public void use( GpuContext context )
+    {
+        prog.use( context );
+        // TODO: Ask Tobi, is this necessary? SceneryContext needs it
+        prog.setUniforms( context );
+    }
+
+    public void bindSamplers( GpuContext context )
+    {
+        prog.bindSamplers( context );
+    }
+
+    public void setUniforms( GpuContext context )
+    {
+        prog.setUniforms( context );
+    }
+
+    static class ConverterSegment
+    {
+        private final Uniform4f uniformOffset;
+        private final Uniform4f uniformScale;
+
+        public ConverterSegment( final SegmentedShader prog, final Segment segment )
+        {
+            uniformOffset = prog.getUniform4f( segment,"offset" );
+            uniformScale = prog.getUniform4f( segment,"scale" );
+        }
+
+        public void setData( ConverterSetup converter )
+        {
+            final double fmin = converter.getDisplayRangeMin() / 0xffff;
+            final double fmax = converter.getDisplayRangeMax() / 0xffff;
+            final double s = 1.0 / ( fmax - fmin );
+            final double o = -fmin * s;
+
+            final int color = converter.getColor().get();
+            final double r = ( double ) ARGBType.red( color ) / 255.0;
+            final double g = ( double ) ARGBType.green( color ) / 255.0;
+            final double b = ( double ) ARGBType.blue( color ) / 255.0;
+
+//			final double l = 0.2126 * r + 0.7152 * g + 0.0722 * b;
+//			final double l = 0.299 * r + 0.587 * g + 0.114 * b;
+
+            uniformOffset.set(
+                    ( float ) ( o * r ),
+                    ( float ) ( o * g ),
+                    ( float ) ( o * b ),
+                    ( float ) ( o ) );
+            uniformScale.set(
+                    ( float ) ( s * r ),
+                    ( float ) ( s * g ),
+                    ( float ) ( s * b ),
+                    ( float ) ( s ) );
+        }
+    }
+
+    static class VolumeSegment
+    {
+        private final Uniform3fv uniformBlockScales;
+        private final UniformSampler uniformLutSampler;
+        private final Uniform3f uniformLutScale;
+        private final Uniform3f uniformLutOffset;
+        private final UniformMatrix4f uniformIm;
+        private final Uniform3f uniformSourcemin;
+        private final Uniform3f uniformSourcemax;
+
+        public VolumeSegment( final SegmentedShader prog, final Segment volume )
+        {
+            uniformBlockScales = prog.getUniform3fv( volume, "blockScales" );
+            uniformLutSampler = prog.getUniformSampler( volume,"lutSampler" );
+            uniformLutScale = prog.getUniform3f( volume, "lutScale" );
+            uniformLutOffset = prog.getUniform3f( volume, "lutOffset" );
+            uniformIm = prog.getUniformMatrix4f( volume, "im" );
+            uniformSourcemin = prog.getUniform3f( volume,"sourcemin" );
+            uniformSourcemax = prog.getUniform3f( volume,"sourcemax" );
+        }
+
+        public void setData( VolumeBlocks blocks )
+        {
+            uniformBlockScales.set( blocks.getLutBlockScales( NUM_BLOCK_SCALES ) );
+            uniformLutSampler.set( blocks.getLookupTexture() );
+            uniformLutScale.set( blocks.getLutScale() );
+            uniformLutOffset.set( blocks.getLutOffset() );
+            uniformIm.set( blocks.getIms() );
+            uniformSourcemin.set( blocks.getSourceLevelMin() );
+            uniformSourcemax.set( blocks.getSourceLevelMax() );
+        }
+    }
+}

--- a/src/main/java/tpietzsch/example2/VolumeBlocks.java
+++ b/src/main/java/tpietzsch/example2/VolumeBlocks.java
@@ -81,12 +81,28 @@ public class VolumeBlocks
 	public void init(
 			final MultiResolutionStack3D< ? > multiResolutionStack,
 			final int viewportWidth,
-			final Matrix4fc pv )
+			final Matrix4fc pv)
 	{
 		this.multiResolutionStack = multiResolutionStack;
 
 		final Matrix4f model = MatrixMath.affine( multiResolutionStack.getSourceTransform(), new Matrix4f() );
 		pvm.set( pv ).mul( model );
+		sizes.init( pvm, viewportWidth, multiResolutionStack.resolutions() );
+		baseLevel = sizes.getBaseLevel();
+	}
+
+	public void initWithModel(
+			final MultiResolutionStack3D< ? > multiResolutionStack,
+			final int viewportWidth,
+			final Matrix4fc pv,
+			final Matrix4fc m)
+	{
+		this.multiResolutionStack = multiResolutionStack;
+
+		final Matrix4f model = MatrixMath.affine( multiResolutionStack.getSourceTransform(), new Matrix4f() );
+		pvm.set( pv )
+				.mul( m )
+				.mul( model );
 		sizes.init( pvm, viewportWidth, multiResolutionStack.resolutions() );
 		baseLevel = sizes.getBaseLevel();
 	}

--- a/src/main/java/tpietzsch/shadergen/AbstractShader.java
+++ b/src/main/java/tpietzsch/shadergen/AbstractShader.java
@@ -609,11 +609,13 @@ public abstract class AbstractShader implements Shader
 		@Override
 		void setInShader( final SetUniforms visitor )
 		{
-			if ( !valid )
+			if ( !valid ) {
 //				throw new IllegalStateException( "Trying to set uniform sampler from texture that has no valid texture unit yet. Forgot to call Shader.bindSamplers()?" );
-				System.out.println( "Trying to set uniform sampler from texture that has no valid texture unit yet. Forgot to call Shader.bindSamplers()?" );
-			else
-				visitor.setUniform1i( name, v0 );
+//				System.out.println( "Trying to set uniform sampler from texture that has no valid texture unit yet. Forgot to call Shader.bindSamplers()?" );
+			}
+			else {
+				visitor.setUniform1i(name, v0);
+			}
 		}
 	}
 }

--- a/src/main/resources/tpietzsch/example2/SceneryMultiVolume.frag
+++ b/src/main/resources/tpietzsch/example2/SceneryMultiVolume.frag
@@ -17,45 +17,45 @@ uniform mat4 transform;
 
 #pragma scenery verbatim
 layout(location = 0) in VertexData {
-    vec2 textureCoord;
-    mat4 inverseProjection;
-    mat4 inverseView;
+	vec2 textureCoord;
+	mat4 inverseProjection;
+	mat4 inverseView;
 } Vertex;
 
 layout(set = 0, binding = 0) uniform VRParameters {
-    mat4 projectionMatrices[2];
-    mat4 inverseProjectionMatrices[2];
-    mat4 headShift;
-    float IPD;
-    int stereoEnabled;
+	mat4 projectionMatrices[2];
+	mat4 inverseProjectionMatrices[2];
+	mat4 headShift;
+	float IPD;
+	int stereoEnabled;
 } vrParameters;
 
 const int MAX_NUM_LIGHTS = 1024;
 
 layout(set = 1, binding = 0) uniform LightParameters {
-    mat4 ViewMatrices[2];
-    mat4 InverseViewMatrices[2];
-    mat4 ProjectionMatrix;
-    mat4 InverseProjectionMatrix;
-    vec3 CamPosition;
+	mat4 ViewMatrices[2];
+	mat4 InverseViewMatrices[2];
+	mat4 ProjectionMatrix;
+	mat4 InverseProjectionMatrix;
+	vec3 CamPosition;
 };
 
 layout(push_constant) uniform currentEye_t {
-    int eye;
+	int eye;
 } currentEye;
 #pragma scenery endverbatim
 
 void main()
 {
-    mat4 ipv = Vertex.inverseView * Vertex.inverseProjection;
+	mat4 ipv = Vertex.inverseView * Vertex.inverseProjection;
 	// frag coord in NDC
 	// TODO: Re-introduce dithering
-    //	vec2 fragCoord = (vrParameters.stereoEnabled ^ 1) * gl_FragCoord.xy + vrParameters.stereoEnabled * vec2((gl_FragCoord.x/2.0 + currentEye.eye * gl_FragCoord.x/2.0), gl_FragCoord.y);
-    //	vec2 viewportSizeActual = (vrParameters.stereoEnabled ^ 1) * viewportSize + vrParameters.stereoEnabled * vec2(viewportSize.x/2.0, viewportSize.y);
-    //	vec2 uv = 2 * ( gl_FragCoord.xy + dsp ) / viewportSizeActual - 1;
-    vec2 uv = Vertex.textureCoord * 2.0 - vec2(1.0);
-    vec2 depthUV = (vrParameters.stereoEnabled ^ 1) * Vertex.textureCoord + vrParameters.stereoEnabled * vec2((Vertex.textureCoord.x/2.0 + currentEye.eye * 0.5), Vertex.textureCoord.y);
-    depthUV = depthUV * 2.0 - vec2(1.0);
+	//	vec2 fragCoord = (vrParameters.stereoEnabled ^ 1) * gl_FragCoord.xy + vrParameters.stereoEnabled * vec2((gl_FragCoord.x/2.0 + currentEye.eye * gl_FragCoord.x/2.0), gl_FragCoord.y);
+	//	vec2 viewportSizeActual = (vrParameters.stereoEnabled ^ 1) * viewportSize + vrParameters.stereoEnabled * vec2(viewportSize.x/2.0, viewportSize.y);
+	//	vec2 uv = 2 * ( gl_FragCoord.xy + dsp ) / viewportSizeActual - 1;
+	vec2 uv = Vertex.textureCoord * 2.0 - vec2(1.0);
+	vec2 depthUV = (vrParameters.stereoEnabled ^ 1) * Vertex.textureCoord + vrParameters.stereoEnabled * vec2((Vertex.textureCoord.x/2.0 + currentEye.eye * 0.5), Vertex.textureCoord.y);
+	depthUV = depthUV * 2.0 - vec2(1.0);
 
 	// NDC of frag on near and far plane
 	vec4 front = vec4( uv, -1, 1 );

--- a/src/main/resources/tpietzsch/example2/SceneryMultiVolume.frag
+++ b/src/main/resources/tpietzsch/example2/SceneryMultiVolume.frag
@@ -1,0 +1,112 @@
+out vec4 FragColor;
+uniform vec2 viewportSize;
+uniform vec2 dsp;
+uniform float fwnw;
+uniform float nw;
+
+uniform sampler3D volumeCache;
+
+// -- comes from CacheSpec -----
+uniform vec3 blockSize;
+uniform vec3 paddedBlockSize;
+uniform vec3 cachePadOffset;
+
+// -- comes from TextureCache --
+uniform vec3 cacheSize; // TODO: get from texture!?
+uniform mat4 transform;
+
+#pragma scenery verbatim
+layout(location = 0) in VertexData {
+    vec2 textureCoord;
+    mat4 inverseProjection;
+    mat4 inverseView;
+} Vertex;
+
+layout(set = 0, binding = 0) uniform VRParameters {
+    mat4 projectionMatrices[2];
+    mat4 inverseProjectionMatrices[2];
+    mat4 headShift;
+    float IPD;
+    int stereoEnabled;
+} vrParameters;
+
+const int MAX_NUM_LIGHTS = 1024;
+
+layout(set = 1, binding = 0) uniform LightParameters {
+    mat4 ViewMatrices[2];
+    mat4 InverseViewMatrices[2];
+    mat4 ProjectionMatrix;
+    mat4 InverseProjectionMatrix;
+    vec3 CamPosition;
+};
+
+layout(push_constant) uniform currentEye_t {
+    int eye;
+} currentEye;
+#pragma scenery endverbatim
+
+void main()
+{
+    mat4 ipv = Vertex.inverseView * Vertex.inverseProjection;
+	// frag coord in NDC
+	// TODO: Re-introduce dithering
+    //	vec2 fragCoord = (vrParameters.stereoEnabled ^ 1) * gl_FragCoord.xy + vrParameters.stereoEnabled * vec2((gl_FragCoord.x/2.0 + currentEye.eye * gl_FragCoord.x/2.0), gl_FragCoord.y);
+    //	vec2 viewportSizeActual = (vrParameters.stereoEnabled ^ 1) * viewportSize + vrParameters.stereoEnabled * vec2(viewportSize.x/2.0, viewportSize.y);
+    //	vec2 uv = 2 * ( gl_FragCoord.xy + dsp ) / viewportSizeActual - 1;
+    vec2 uv = Vertex.textureCoord * 2.0 - vec2(1.0);
+
+	// NDC of frag on near and far plane
+	vec4 front = vec4( uv, -1, 1 );
+	vec4 back = vec4( uv, 1, 1 );
+
+	// calculate eye ray in world space
+	vec4 wfront = ipv * front;
+	wfront *= 1 / wfront.w;
+	vec4 wback = ipv * back;
+	wback *= 1 / wback.w;
+
+	// -- bounding box intersection for all volumes ----------
+	float tnear = 1, tfar = 0, tmax = getMaxDepth( uv );
+	float n, f;
+
+	// $repeat:{vis,intersectBoundingBox|
+	bool vis = false;
+	intersectBoundingBox( wfront, wback, n, f );
+	f = min( tmax, f );
+	if ( n < f )
+	{
+		tnear = min( tnear, max( 0, n ) );
+		tfar = max( tfar, f );
+		vis = true;
+	}
+	// }$
+
+	// -------------------------------------------------------
+
+
+	if ( tnear < tfar )
+	{
+		vec4 fb = wback - wfront;
+		int numSteps =
+			( fwnw > 0.00001 )
+			? int ( log( ( tfar * fwnw + nw ) / ( tnear * fwnw + nw ) ) / log ( 1 + fwnw ) )
+			: int ( trunc( ( tfar - tnear ) / nw + 1 ) );
+
+		float step = tnear;
+		vec4 v = vec4( 0 );
+		for ( int i = 0; i < numSteps; ++i, step += nw + step * fwnw )
+		{
+			vec4 wpos = mix( wfront, wback, step );
+			// $repeat:{vis,blockTexture,convert|
+			if ( vis )
+			{
+				float x = blockTexture( wpos, volumeCache, cacheSize, blockSize, paddedBlockSize, cachePadOffset );
+				v = max( v, convert( x ) );
+			}
+			// }$
+		}
+		FragColor = v;
+	}
+	else
+		FragColor = vec4( 0, 0, 0, 0 );
+}

--- a/src/main/resources/tpietzsch/example2/SceneryMultiVolume.frag
+++ b/src/main/resources/tpietzsch/example2/SceneryMultiVolume.frag
@@ -54,6 +54,8 @@ void main()
     //	vec2 viewportSizeActual = (vrParameters.stereoEnabled ^ 1) * viewportSize + vrParameters.stereoEnabled * vec2(viewportSize.x/2.0, viewportSize.y);
     //	vec2 uv = 2 * ( gl_FragCoord.xy + dsp ) / viewportSizeActual - 1;
     vec2 uv = Vertex.textureCoord * 2.0 - vec2(1.0);
+    vec2 depthUV = (vrParameters.stereoEnabled ^ 1) * Vertex.textureCoord + vrParameters.stereoEnabled * vec2((Vertex.textureCoord.x/2.0 + currentEye.eye * 0.5), Vertex.textureCoord.y);
+    depthUV = depthUV * 2.0 - vec2(1.0);
 
 	// NDC of frag on near and far plane
 	vec4 front = vec4( uv, -1, 1 );
@@ -66,7 +68,7 @@ void main()
 	wback *= 1 / wback.w;
 
 	// -- bounding box intersection for all volumes ----------
-	float tnear = 1, tfar = 0, tmax = getMaxDepth( uv );
+	float tnear = 1, tfar = 0, tmax = getMaxDepth( depthUV );
 	float n, f;
 
 	// $repeat:{vis,intersectBoundingBox|

--- a/src/main/resources/tpietzsch/example2/SceneryMultiVolume.frag
+++ b/src/main/resources/tpietzsch/example2/SceneryMultiVolume.frag
@@ -54,6 +54,7 @@ void main()
     //	vec2 viewportSizeActual = (vrParameters.stereoEnabled ^ 1) * viewportSize + vrParameters.stereoEnabled * vec2(viewportSize.x/2.0, viewportSize.y);
     //	vec2 uv = 2 * ( gl_FragCoord.xy + dsp ) / viewportSizeActual - 1;
     vec2 uv = Vertex.textureCoord * 2.0 - vec2(1.0);
+    vec2 depthUV = (vrParameters.stereoEnabled ^ 1) * uv + vrParameters.stereoEnabled * vec2((uv.x/2.0 + currentEye.eye * 0.5), uv.y);
 
 	// NDC of frag on near and far plane
 	vec4 front = vec4( uv, -1, 1 );
@@ -66,7 +67,7 @@ void main()
 	wback *= 1 / wback.w;
 
 	// -- bounding box intersection for all volumes ----------
-	float tnear = 1, tfar = 0, tmax = getMaxDepth( uv );
+	float tnear = 1, tfar = 0, tmax = getMaxDepth( depthUV );
 	float n, f;
 
 	// $repeat:{vis,intersectBoundingBox|

--- a/src/main/resources/tpietzsch/example2/SceneryMultiVolume.frag
+++ b/src/main/resources/tpietzsch/example2/SceneryMultiVolume.frag
@@ -1,0 +1,78 @@
+out vec4 FragColor;
+uniform vec2 viewportSize;
+uniform vec2 dsp;
+uniform mat4 ipv;
+uniform float fwnw;
+uniform float nw;
+
+uniform sampler3D volumeCache;
+
+// -- comes from CacheSpec -----
+uniform vec3 blockSize;
+uniform vec3 paddedBlockSize;
+uniform vec3 cachePadOffset;
+
+// -- comes from TextureCache --
+uniform vec3 cacheSize; // TODO: get from texture!?
+uniform mat4 transform;
+
+void main()
+{
+	// frag coord in NDC
+	vec2 uv = 2 * ( gl_FragCoord.xy + dsp ) / viewportSize - 1;
+
+	// NDC of frag on near and far plane
+	vec4 front = vec4( uv, -1, 1 );
+	vec4 back = vec4( uv, 1, 1 );
+
+	// calculate eye ray in world space
+	vec4 wfront = ipv * front;
+	wfront *= 1 / wfront.w;
+	vec4 wback = ipv * back;
+	wback *= 1 / wback.w;
+
+	// -- bounding box intersection for all volumes ----------
+	float tnear = 1, tfar = 0, tmax = getMaxDepth( uv );
+	float n, f;
+
+	// $repeat:{vis,intersectBoundingBox|
+	bool vis = false;
+	intersectBoundingBox( wfront, wback, n, f );
+	f = min( tmax, f );
+	if ( n < f )
+	{
+		tnear = min( tnear, max( 0, n ) );
+		tfar = max( tfar, f );
+		vis = true;
+	}
+	// }$
+
+	// -------------------------------------------------------
+
+
+	if ( tnear < tfar )
+	{
+		vec4 fb = wback - wfront;
+		int numSteps =
+			( fwnw > 0.00001 )
+			? int ( log( ( tfar * fwnw + nw ) / ( tnear * fwnw + nw ) ) / log ( 1 + fwnw ) )
+			: int ( trunc( ( tfar - tnear ) / nw + 1 ) );
+
+		float step = tnear;
+		vec4 v = vec4( 0 );
+		for ( int i = 0; i < numSteps; ++i, step += nw + step * fwnw )
+		{
+			vec4 wpos = mix( wfront, wback, step );
+			// $repeat:{vis,blockTexture,convert|
+			if ( vis )
+			{
+				float x = blockTexture( wpos, volumeCache, cacheSize, blockSize, paddedBlockSize, cachePadOffset );
+				v = max( v, convert( x ) );
+			}
+			// }$
+		}
+		FragColor = v;
+	}
+	else
+		FragColor = vec4( 0, 0, 0, 0 );
+}

--- a/src/main/resources/tpietzsch/example2/SceneryMultiVolume.vert
+++ b/src/main/resources/tpietzsch/example2/SceneryMultiVolume.vert
@@ -1,0 +1,8 @@
+layout (location = 0) in vec3 aPos;
+
+uniform mat4 transform;
+
+void main()
+{
+	gl_Position = transform * vec4( aPos, 1.0 );
+}

--- a/src/main/resources/tpietzsch/example2/SceneryMultiVolume.vert
+++ b/src/main/resources/tpietzsch/example2/SceneryMultiVolume.vert
@@ -1,0 +1,49 @@
+
+#pragma scenery verbatim
+layout(location = 0) in vec3 vertexPosition;
+layout(location = 1) in vec3 vertexNormal;
+layout(location = 2) in vec2 vertexTexCoord;
+
+layout(location = 0) out VertexData {
+    vec2 textureCoord;
+    mat4 inverseProjection;
+    mat4 inverseView;
+} Vertex;
+
+layout(set = 0, binding = 0) uniform VRParameters {
+    mat4 projectionMatrices[2];
+    mat4 inverseProjectionMatrices[2];
+    mat4 headShift;
+    float IPD;
+    int stereoEnabled;
+} vrParameters;
+
+const int MAX_NUM_LIGHTS = 1024;
+
+layout(set = 1, binding = 0) uniform LightParameters {
+    mat4 ViewMatrices[2];
+    mat4 InverseViewMatrices[2];
+    mat4 ProjectionMatrix;
+    mat4 InverseProjectionMatrix;
+    vec3 CamPosition;
+};
+
+layout(push_constant) uniform currentEye_t {
+    int eye;
+} currentEye;
+#pragma scenery endverbatim
+
+void main()
+{
+	mat4 view;
+	mat4 projectionMatrix;
+
+    view = (vrParameters.stereoEnabled ^ 1) * ViewMatrices[0] + (vrParameters.stereoEnabled * ViewMatrices[currentEye.eye]);
+	projectionMatrix = (vrParameters.stereoEnabled ^ 1) * ProjectionMatrix + vrParameters.stereoEnabled * vrParameters.projectionMatrices[currentEye.eye];
+
+    Vertex.inverseProjection = (vrParameters.stereoEnabled ^ 1) * InverseProjectionMatrix + (vrParameters.stereoEnabled * vrParameters.inverseProjectionMatrices[currentEye.eye]);
+    Vertex.inverseView = inverse(view);
+
+    Vertex.textureCoord = vertexTexCoord;
+    gl_Position = vec4(vertexPosition, 1.0f);
+}

--- a/src/main/resources/tpietzsch/example2/SceneryMultiVolume.vert
+++ b/src/main/resources/tpietzsch/example2/SceneryMultiVolume.vert
@@ -4,31 +4,31 @@ layout(location = 1) in vec3 vertexNormal;
 layout(location = 2) in vec2 vertexTexCoord;
 
 layout(location = 0) out VertexData {
-    vec2 textureCoord;
-    mat4 inverseProjection;
-    mat4 inverseView;
+	vec2 textureCoord;
+	mat4 inverseProjection;
+	mat4 inverseView;
 } Vertex;
 
 layout(set = 0, binding = 0) uniform VRParameters {
-    mat4 projectionMatrices[2];
-    mat4 inverseProjectionMatrices[2];
-    mat4 headShift;
-    float IPD;
-    int stereoEnabled;
+	mat4 projectionMatrices[2];
+	mat4 inverseProjectionMatrices[2];
+	mat4 headShift;
+	float IPD;
+	int stereoEnabled;
 } vrParameters;
 
 const int MAX_NUM_LIGHTS = 1024;
 
 layout(set = 1, binding = 0) uniform LightParameters {
-    mat4 ViewMatrices[2];
-    mat4 InverseViewMatrices[2];
-    mat4 ProjectionMatrix;
-    mat4 InverseProjectionMatrix;
-    vec3 CamPosition;
+	mat4 ViewMatrices[2];
+	mat4 InverseViewMatrices[2];
+	mat4 ProjectionMatrix;
+	mat4 InverseProjectionMatrix;
+	vec3 CamPosition;
 };
 
 layout(push_constant) uniform currentEye_t {
-    int eye;
+	int eye;
 } currentEye;
 #pragma scenery endverbatim
 
@@ -37,12 +37,12 @@ void main()
 	mat4 view;
 	mat4 projectionMatrix;
 
-    view = (vrParameters.stereoEnabled ^ 1) * ViewMatrices[0] + (vrParameters.stereoEnabled * ViewMatrices[currentEye.eye]);
+	view = (vrParameters.stereoEnabled ^ 1) * ViewMatrices[0] + (vrParameters.stereoEnabled * ViewMatrices[currentEye.eye]);
 	projectionMatrix = (vrParameters.stereoEnabled ^ 1) * ProjectionMatrix + vrParameters.stereoEnabled * vrParameters.projectionMatrices[currentEye.eye];
 
-    Vertex.inverseProjection = (vrParameters.stereoEnabled ^ 1) * InverseProjectionMatrix + (vrParameters.stereoEnabled * vrParameters.inverseProjectionMatrices[currentEye.eye]);
-    Vertex.inverseView = inverse(view);
+	Vertex.inverseProjection = (vrParameters.stereoEnabled ^ 1) * InverseProjectionMatrix + (vrParameters.stereoEnabled * vrParameters.inverseProjectionMatrices[currentEye.eye]);
+	Vertex.inverseView = inverse(view);
 
-    Vertex.textureCoord = vertexTexCoord;
-    gl_Position = vec4(vertexPosition, 1.0f);
+	Vertex.textureCoord = vertexTexCoord;
+	gl_Position = vec4(vertexPosition, 1.0f);
 }

--- a/src/main/resources/tpietzsch/example2/ex8vol.fp
+++ b/src/main/resources/tpietzsch/example2/ex8vol.fp
@@ -14,6 +14,7 @@ uniform vec3 cachePadOffset;
 
 // -- comes from TextureCache --
 uniform vec3 cacheSize; // TODO: get from texture!?
+uniform mat4 transform;
 
 void main()
 {

--- a/src/main/resources/tpietzsch/example2/maxdepthtexture_scenery.fp
+++ b/src/main/resources/tpietzsch/example2/maxdepthtexture_scenery.fp
@@ -9,11 +9,11 @@ float tw( float zd )
 
 float getMaxDepth( vec2 uv )
 {
-	//return tw( texture( InputZBuffer, ( uv + 1 ) / 2 ).x );
-#ifndef OPENGL
-    float currentSceneDepth = texture(InputZBuffer, uv).r;
-#else
-    float currentSceneDepth = texture(InputZBuffer, uv).r * 2.0 - 1.0;
-#endif
-	return currentSceneDepth;
+	return tw( texture( InputZBuffer, ( uv + 1 ) / 2 ).x );
+//#ifndef OPENGL
+//    float currentSceneDepth = texture(InputZBuffer, uv).r;
+//#else
+//    float currentSceneDepth = texture(InputZBuffer, uv).r * 2.0 - 1.0;
+//#endif
+//	return tw(currentSceneDepth);
 }

--- a/src/main/resources/tpietzsch/example2/maxdepthtexture_scenery.fp
+++ b/src/main/resources/tpietzsch/example2/maxdepthtexture_scenery.fp
@@ -1,0 +1,19 @@
+uniform sampler2D InputZBuffer;
+uniform float xf;
+
+float tw( float zd )
+{
+	return ( xf * zd ) / ( 2 * xf * zd - xf - zd + 1 );
+}
+
+
+float getMaxDepth( vec2 uv )
+{
+	//return tw( texture( InputZBuffer, ( uv + 1 ) / 2 ).x );
+#ifndef OPENGL
+    float currentSceneDepth = texture(InputZBuffer, uv).r;
+#else
+    float currentSceneDepth = texture(InputZBuffer, uv).r * 2.0 - 1.0;
+#endif
+	return currentSceneDepth;
+}


### PR DESCRIPTION
This PR contains:

* additions to MultiVolumeShaderMip9 to allow e.g. setting the (uniform) name of the depth texture
* addition of a initWithModel() function to VolumeBlocks to initialize a VB with an additional transformation
* adds SceneryMultiVolumeShaderMip, a scenery-specific version on MultiVolumeShaderMip9, including custom shaders which also support stereo rendering (note: after cleanup, this could potentially be moved to scenery?)

PS: If you merge this, I'd be super-happy about a 0.1.3 release :)
