### PR TITLE
Flexible shaders

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,8 +70,8 @@
 		<license.licenseName>bsd_2</license.licenseName>
 		<license.copyrightOwners>Tobias Pietzsch</license.copyrightOwners>
 
-		<bigdataviewer-core.version>7.0.0</bigdataviewer-core.version>
-		<bigdataviewer-vistools.version>1.0.0-beta-15</bigdataviewer-vistools.version>
+		<bigdataviewer-core.version>8.0.0</bigdataviewer-core.version>
+		<bigdataviewer-vistools.version>1.0.0-beta-18</bigdataviewer-vistools.version>
 		<ST4.version>4.0.8</ST4.version>
 
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->

--- a/src/main/java/tpietzsch/backend/Texture.java
+++ b/src/main/java/tpietzsch/backend/Texture.java
@@ -8,7 +8,7 @@ public interface Texture
 		R16( 2 ),
 		RGBA8( 4 ),
 		RGBA8UI( 4 ),
-		FLOAT32( 4 ),
+		R32F( 4 ),
 		UNKNOWN( -1 );
 
 		InternalFormat( final int bytesPerElement )

--- a/src/main/java/tpietzsch/backend/Texture.java
+++ b/src/main/java/tpietzsch/backend/Texture.java
@@ -8,6 +8,7 @@ public interface Texture
 		R16( 2 ),
 		RGBA8( 4 ),
 		RGBA8UI( 4 ),
+		FLOAT32( 4 ),
 		UNKNOWN( -1 );
 
 		InternalFormat( final int bytesPerElement )

--- a/src/main/java/tpietzsch/backend/jogl/JoglGpuContext.java
+++ b/src/main/java/tpietzsch/backend/jogl/JoglGpuContext.java
@@ -17,8 +17,10 @@ import tpietzsch.shadergen.Shader;
 
 import static com.jogamp.opengl.GL.GL_ACTIVE_TEXTURE;
 import static com.jogamp.opengl.GL.GL_CLAMP_TO_EDGE;
+import static com.jogamp.opengl.GL.GL_FLOAT;
 import static com.jogamp.opengl.GL.GL_LINEAR;
 import static com.jogamp.opengl.GL.GL_NEAREST;
+import static com.jogamp.opengl.GL.GL_R32F;
 import static com.jogamp.opengl.GL.GL_R8;
 import static com.jogamp.opengl.GL.GL_REPEAT;
 import static com.jogamp.opengl.GL.GL_RGBA;
@@ -418,6 +420,8 @@ public class JoglGpuContext implements GpuContext
 			return GL_RGBA8;
 		case RGBA8UI:
 			return GL_RGBA8UI;
+		case R32F:
+			return GL_R32F;
 		default:
 			throw new IllegalArgumentException();
 		}
@@ -435,6 +439,8 @@ public class JoglGpuContext implements GpuContext
 			return GL_RGBA;
 		case RGBA8UI:
 			return GL_RGBA_INTEGER;
+		case R32F:
+			return GL_RED;
 		default:
 			throw new IllegalArgumentException();
 		}
@@ -452,6 +458,8 @@ public class JoglGpuContext implements GpuContext
 			return GL_UNSIGNED_BYTE;
 		case RGBA8UI:
 			return GL_UNSIGNED_BYTE;
+		case R32F:
+			return GL_FLOAT;
 		default:
 			throw new IllegalArgumentException();
 		}

--- a/src/main/java/tpietzsch/backend/jogl/JoglGpuContext.java
+++ b/src/main/java/tpietzsch/backend/jogl/JoglGpuContext.java
@@ -367,7 +367,6 @@ public class JoglGpuContext implements GpuContext
 		} );
 	}
 
-
 	private static int target( Texture texture )
 	{
 		return target( texture.texDims() );
@@ -375,7 +374,7 @@ public class JoglGpuContext implements GpuContext
 
 	private static int target( final int numTexDimensions )
 	{
-		switch( numTexDimensions )
+		switch ( numTexDimensions )
 		{
 		case 1:
 			return GL_TEXTURE_1D;
@@ -395,7 +394,7 @@ public class JoglGpuContext implements GpuContext
 
 	private static int targetBinding( final int numTexDimensions )
 	{
-		switch( numTexDimensions )
+		switch ( numTexDimensions )
 		{
 		case 1:
 			return GL_TEXTURE_BINDING_1D;
@@ -410,7 +409,7 @@ public class JoglGpuContext implements GpuContext
 
 	private static int internalFormat( Texture texture )
 	{
-		switch( texture.texInternalFormat() )
+		switch ( texture.texInternalFormat() )
 		{
 		case R8:
 			return GL_R8;
@@ -429,7 +428,7 @@ public class JoglGpuContext implements GpuContext
 
 	private static int format( Texture texture )
 	{
-		switch( texture.texInternalFormat() )
+		switch ( texture.texInternalFormat() )
 		{
 		case R8:
 			return GL_RED;
@@ -448,7 +447,7 @@ public class JoglGpuContext implements GpuContext
 
 	private static int type( Texture texture )
 	{
-		switch( texture.texInternalFormat() )
+		switch ( texture.texInternalFormat() )
 		{
 		case R8:
 			return GL_UNSIGNED_BYTE;
@@ -467,7 +466,7 @@ public class JoglGpuContext implements GpuContext
 
 	private static int magFilter( Texture texture )
 	{
-		switch( texture.texMagFilter() )
+		switch ( texture.texMagFilter() )
 		{
 		case NEAREST:
 			return GL_NEAREST;
@@ -480,7 +479,7 @@ public class JoglGpuContext implements GpuContext
 
 	private static int minFilter( Texture texture )
 	{
-		switch( texture.texMinFilter() )
+		switch ( texture.texMinFilter() )
 		{
 		case NEAREST:
 			return GL_NEAREST;
@@ -493,7 +492,7 @@ public class JoglGpuContext implements GpuContext
 
 	private static int wrap( Texture texture )
 	{
-		switch( texture.texWrap() )
+		switch ( texture.texWrap() )
 		{
 		case CLAMP_TO_EDGE:
 			return GL_CLAMP_TO_EDGE;

--- a/src/main/java/tpietzsch/example2/MultiVolumeShaderMip.java
+++ b/src/main/java/tpietzsch/example2/MultiVolumeShaderMip.java
@@ -40,7 +40,7 @@ public class MultiVolumeShaderMip
 
 	// step size on near plane = pixel_width
 	// step size on far plane = degrade * pixel_width
-	private final double degrade;
+	private double degrade;
 
 	private final SegmentedShader prog;
 	private final VolumeSegment[] volumeSegments;
@@ -282,6 +282,10 @@ public class MultiVolumeShaderMip
 		uniformViewportSize.set( dither.effectiveViewportWidth(), dither.effectiveViewportHeight() );
 		uniformTransform.set( dither.ndcTransform( step ) );
 		uniformDsp.set( dither.fragShift( step ) );
+	}
+
+	public void setDegrade( Double farPlaneStepSizeDegradation) {
+		degrade = farPlaneStepSizeDegradation;
 	}
 
 	/**

--- a/src/main/java/tpietzsch/example2/MultiVolumeShaderMip.java
+++ b/src/main/java/tpietzsch/example2/MultiVolumeShaderMip.java
@@ -225,7 +225,7 @@ public class MultiVolumeShaderMip
 				"convert", "offset", "scale" ) );
 		segments.put( SegmentType.MaxDepth, new SegmentTemplate(
 				useDepthTexture ? "maxdepthtexture.frag" : "maxdepthone.frag" ) );
-		segments.put( SegmentType.VertexShader, new SegmentTemplate( "multi_volume.frag" ) );
+		segments.put( SegmentType.VertexShader, new SegmentTemplate( "multi_volume.vert" ) );
 		segments.put( SegmentType.FragmentShader, new SegmentTemplate(
 				"multi_volume.frag",
 				"intersectBoundingBox", "vis", "SampleVolume", "Convert", "Accumulate" ) );

--- a/src/main/java/tpietzsch/example2/MultiVolumeShaderMip.java
+++ b/src/main/java/tpietzsch/example2/MultiVolumeShaderMip.java
@@ -67,7 +67,7 @@ public class MultiVolumeShaderMip
 
 	public MultiVolumeShaderMip( VolumeShaderSignature signature, final boolean useDepthTexture, final double degrade,
 			final Map< SegmentType, SegmentTemplate > segments,
-			final BiConsumer< Map< SegmentType, SegmentTemplate >, Map< SegmentType, Segment > > additionalBindings,
+			final BiConsumer< Map< SegmentType, SegmentTemplate >, Map< SegmentType, Segment > > runBeforeBinding,
 			final String depthTextureName )
 	{
 		this.signature = signature;
@@ -145,8 +145,8 @@ public class MultiVolumeShaderMip
 				break;
 			}
 
-			if ( additionalBindings != null )
-				additionalBindings.accept( segments, instancedSegments );
+			if ( runBeforeBinding != null )
+				runBeforeBinding.accept( segments, instancedSegments );
 
 			fp.bind( "intersectBoundingBox", i, sampleVolume );
 			fp.bind( "vis", i, accumulate );
@@ -281,9 +281,9 @@ public class MultiVolumeShaderMip
 		final VolumeSignature vs = signature.getVolumeSignatures().get( index );
 
 		if ( vs.getSourceStackType() == MULTIRESOLUTION )
-			( ( VolumeBlocksSegment ) volumeSegments[ index ] ).addSampler( prog, name, texture );
+			( ( VolumeBlocksSegment ) volumeSegments[ index ] ).putSampler( prog, name, texture );
 		else
-			( ( VolumeSimpleSegment ) volumeSegments[ index ] ).addSampler( prog, name, texture );
+			( ( VolumeSimpleSegment ) volumeSegments[ index ] ).putSampler( prog, name, texture );
 	}
 
 	public void setVolume( int index, VolumeBlocks volume )
@@ -488,7 +488,7 @@ public class MultiVolumeShaderMip
 			additionalSamplers.forEach( ( name, entry ) -> entry.getKey().set( entry.getValue() ) );
 		}
 
-		public void addSampler( final SegmentedShader prog, final String name, Texture texture )
+		public void putSampler( final SegmentedShader prog, final String name, Texture texture )
 		{
 			final UniformSampler sampler = prog.getUniformSampler( volume, name );
 			final AbstractMap.SimpleEntry< UniformSampler, Texture > entry = new AbstractMap.SimpleEntry<>( sampler, texture );
@@ -531,7 +531,7 @@ public class MultiVolumeShaderMip
 			additionalSamplers.forEach( ( name, entry ) -> entry.getKey().set( entry.getValue() ) );
 		}
 
-		public void addSampler( final SegmentedShader prog, final String name, Texture texture )
+		public void putSampler( final SegmentedShader prog, final String name, Texture texture )
 		{
 			final UniformSampler sampler = prog.getUniformSampler( volume, name );
 			final AbstractMap.SimpleEntry< UniformSampler, Texture > entry = new AbstractMap.SimpleEntry<>( sampler, texture );

--- a/src/main/java/tpietzsch/shadergen/generate/SegmentType.java
+++ b/src/main/java/tpietzsch/shadergen/generate/SegmentType.java
@@ -1,0 +1,14 @@
+package tpietzsch.shadergen.generate;
+
+public enum SegmentType {
+    SampleMultiresolutionVolume,
+    SampleVolume,
+    SampleRGBAVolume,
+    Convert,
+    ConvertRGBA,
+    MaxDepth,
+    VertexShader,
+    FragmentShader,
+    AccumulatorMultiresolution,
+    Accumulator
+}

--- a/src/main/java/tpietzsch/shadergen/generate/SegmentType.java
+++ b/src/main/java/tpietzsch/shadergen/generate/SegmentType.java
@@ -1,14 +1,15 @@
 package tpietzsch.shadergen.generate;
 
-public enum SegmentType {
-    SampleMultiresolutionVolume,
-    SampleVolume,
-    SampleRGBAVolume,
-    Convert,
-    ConvertRGBA,
-    MaxDepth,
-    VertexShader,
-    FragmentShader,
-    AccumulatorMultiresolution,
-    Accumulator
+public enum SegmentType
+{
+	SampleMultiresolutionVolume,
+	SampleVolume,
+	SampleRGBAVolume,
+	Convert,
+	ConvertRGBA,
+	MaxDepth,
+	VertexShader,
+	FragmentShader,
+	AccumulatorMultiresolution,
+	Accumulator
 }


### PR DESCRIPTION
This PR introduces some more flexiblility in MultiVolumeShaderMip in order to be able to replace all parts of the created shader, so different sampling strategies, etc. become possible without creating a huge single shader.

In addition, it makes the `degrade` parameter accessible, and allows for adding custom samplers.