### PR TITLE
Add Maven Scijava version badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 [![Build Status](https://github.com/bigdataviewer/bigvolumeviewer-core/actions/workflows/build.yml/badge.svg)](https://github.com/bigdataviewer/bigvolumeviewer-core/actions/workflows/build.yml)
+[![Maven Scijava Version](https://img.shields.io/github/v/tag/bigdataviewer/bigvolumeviewer-core?label=Version-[Maven%20Scijava])](https://maven.scijava.org/#browse/browse:releases:sc%2Ffiji%2Fbigvolumeviewer)
 
 # BigVolumeViewer


### PR DESCRIPTION
Just for convenience - I find it useful to have the latest release version in maven directly on the repo readme.