### PR TITLE
  Implement timePointListeners() for AbstractViewerPanel harmonization

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,6 +154,7 @@
 		<dependency>
 			<groupId>sc.fiji</groupId>
 			<artifactId>bigdataviewer-core</artifactId>
+			<version>10.6.8</version>
 		</dependency>
 		<dependency>
 			<groupId>sc.fiji</groupId>
@@ -182,4 +183,19 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<!-- Use source/target instead of release to allow sun.misc.Unsafe access on JDK 16+ -->
+					<release combine.self="override"/>
+					<source>1.8</source>
+					<target>1.8</target>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/src/main/java/bvv/core/VolumeViewerPanel.java
+++ b/src/main/java/bvv/core/VolumeViewerPanel.java
@@ -28,19 +28,65 @@
  */
 package bvv.core;
 
+import static bdv.ui.UIUtils.TextPosition.TOP_RIGHT;
+import static bdv.viewer.DisplayMode.SINGLE;
+import static bdv.viewer.Interpolation.NEARESTNEIGHBOR;
+import static bvv.core.render.VolumeRenderer.RepaintType.FULL;
+import static bvv.core.render.VolumeRenderer.RepaintType.LOAD;
+import static bvv.core.render.VolumeRenderer.RepaintType.NONE;
+import static bvv.core.render.VolumeRenderer.RepaintType.SCENE;
+import static com.jogamp.opengl.GL.GL_DEPTH_TEST;
+import static com.jogamp.opengl.GL.GL_LESS;
+import static com.jogamp.opengl.GL.GL_RGB8;
+
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Font;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.event.ComponentAdapter;
+import java.awt.event.ComponentEvent;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+import javax.swing.DefaultBoundedRangeModel;
+import javax.swing.JSlider;
+import javax.swing.SwingConstants;
+import javax.swing.SwingUtilities;
+
+import org.jdom2.Element;
+import org.joml.Matrix4f;
+import org.scijava.listeners.Listeners;
+import org.scijava.ui.behaviour.io.InputTriggerConfig;
+
+import com.jogamp.opengl.GL3;
+import com.jogamp.opengl.GLAutoDrawable;
+import com.jogamp.opengl.GLEventListener;
+
 import bdv.TransformEventHandler;
 import bdv.TransformState;
 import bdv.cache.CacheControl;
 import bdv.tools.brightness.ConverterSetup;
+import bdv.ui.UIUtils;
 import bdv.util.Prefs;
 import bdv.viewer.AbstractViewerPanel;
+import bdv.viewer.BasicViewerState;
 import bdv.viewer.ConverterSetups;
 import bdv.viewer.DisplayMode;
 import bdv.viewer.NavigationActions;
 import bdv.viewer.OverlayRenderer;
 import bdv.viewer.Source;
 import bdv.viewer.SourceAndConverter;
+import bdv.viewer.SourceGroup;
 import bdv.viewer.SynchronizedViewerState;
+import bdv.viewer.ViewerState;
 import bdv.viewer.TimePointListener;
 import bdv.viewer.TransformListener;
 import bdv.viewer.ViewerPanel;
@@ -56,55 +102,20 @@ import bdv.viewer.overlay.MultiBoxOverlayRenderer;
 import bdv.viewer.overlay.ScaleBarOverlayRenderer;
 import bdv.viewer.overlay.SourceInfoOverlayRenderer;
 import bdv.viewer.render.PainterThread;
-import bdv.viewer.state.SourceGroup;
-import bdv.viewer.state.ViewerState;
 import bdv.viewer.state.XmlIoViewerState;
+import bvv.core.multires.SourceStacks;
+import bvv.core.multires.Stack3D;
+import bvv.core.offscreen.OffScreenFrameBuffer;
+import bvv.core.offscreen.OffScreenFrameBufferWithDepth;
 import bvv.core.render.RenderData;
 import bvv.core.render.VolumeRenderer;
+import bvv.core.render.VolumeRenderer.RepaintType;
 import bvv.core.util.MatrixMath;
-import com.jogamp.opengl.GL3;
-import com.jogamp.opengl.GLAutoDrawable;
-import com.jogamp.opengl.GLEventListener;
-import java.awt.BorderLayout;
-import java.awt.Color;
-import java.awt.Component;
-import java.awt.Font;
-import java.awt.Graphics;
-import java.awt.Graphics2D;
-import java.awt.event.ComponentAdapter;
-import java.awt.event.ComponentEvent;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-import javax.swing.DefaultBoundedRangeModel;
-import javax.swing.JSlider;
-import javax.swing.SwingConstants;
-import javax.swing.SwingUtilities;
 import net.imglib2.RealLocalizable;
 import net.imglib2.RealPoint;
 import net.imglib2.RealPositionable;
 import net.imglib2.cache.iotiming.CacheIoTiming;
 import net.imglib2.realtransform.AffineTransform3D;
-import org.jdom2.Element;
-import org.joml.Matrix4f;
-import org.scijava.listeners.Listeners;
-import org.scijava.ui.behaviour.io.InputTriggerConfig;
-import bvv.core.render.VolumeRenderer.RepaintType;
-import bvv.core.multires.SourceStacks;
-import bvv.core.multires.Stack3D;
-import bvv.core.offscreen.OffScreenFrameBuffer;
-import bvv.core.offscreen.OffScreenFrameBufferWithDepth;
-
-import static com.jogamp.opengl.GL.GL_DEPTH_TEST;
-import static com.jogamp.opengl.GL.GL_LESS;
-import static com.jogamp.opengl.GL.GL_RGB8;
-import static bvv.core.render.VolumeRenderer.RepaintType.FULL;
-import static bvv.core.render.VolumeRenderer.RepaintType.LOAD;
-import static bvv.core.render.VolumeRenderer.RepaintType.NONE;
-import static bvv.core.render.VolumeRenderer.RepaintType.SCENE;
 
 public class VolumeViewerPanel
 		extends AbstractViewerPanel
@@ -162,10 +173,14 @@ public class VolumeViewerPanel
 	protected final int maxRenderMillis;
 
 	/**
-	 * Currently rendered state (visible sources, transformation, timepoint,
-	 * etc.) A copy can be obtained by {@link #getState()}.
+	 * Currently rendered state (visible sources, transformation, timepoint, etc.)
 	 */
-	protected final ViewerState state;
+	private final SynchronizedViewerState state;
+
+	/**
+	 * Legacy wrapper around {@code state} to support deprecated API
+	 */
+	private final bdv.viewer.state.ViewerState deprecatedState;
 
 	private final ConverterSetups setups;
 
@@ -244,17 +259,17 @@ public class VolumeViewerPanel
 
 	/**
 	 * Current animator for viewer transform, or null. This is for example used
-	 * to make smooth transitions when {@link #align(AlignPlane)} aligning to
+	 * to make smooth transitions when {@link #align(AlignPlane) aligning to
 	 * orthogonal planes}.
 	 */
-	protected AbstractTransformAnimator currentAnimator = null;
+	private AtomicReference<AbstractTransformAnimator> currentAnimator = new AtomicReference<>();
 
 	/**
 	 * A list of currently incomplete (see {@link OverlayAnimator#isComplete()})
 	 * animators. Initially, this contains a {@link TextOverlayAnimator} showing
 	 * the "press F1 for help" message.
 	 */
-	protected final ArrayList< OverlayAnimator > overlayAnimators;
+	private final ArrayList< OverlayAnimator > overlayAnimators;
 
 	/**
 	 * Fade-out overlay of recent messages. See {@link #showMessage(String)}.
@@ -286,21 +301,14 @@ public class VolumeViewerPanel
 
 		this.cacheControl = cacheControl;
 
-		final int numGroups = options.getNumSourceGroups();
-		final ArrayList< SourceGroup > groups = new ArrayList<>( numGroups );
-		for ( int i = 0; i < numGroups; ++i )
-			groups.add( new SourceGroup( "group " + Integer.toString( i + 1 ) ) );
-		state = new ViewerState( sources, groups, numTimepoints );
-		for ( int i = Math.min( numGroups, sources.size() ) - 1; i >= 0; --i )
-			state.getSourceGroups().get( i ).addSource( i );
+		state = setupState( sources, numTimepoints, options.getNumSourceGroups() );
+		deprecatedState = new bdv.viewer.state.ViewerState( state );
 
-		if ( !sources.isEmpty() )
-			state.setCurrentSource( 0 );
 		multiBoxOverlayRenderer = new MultiBoxOverlayRenderer();
 		sourceInfoOverlayRenderer = new SourceInfoOverlayRenderer();
 		scaleBarOverlayRenderer = new ScaleBarOverlayRenderer();
 
-		setups = new ConverterSetups( state() );
+		setups = new ConverterSetups( state );
 		setups.listeners().add( s -> requestRepaint() );
 
 		threadGroup = new ThreadGroup( this.toString() );
@@ -352,7 +360,7 @@ public class VolumeViewerPanel
 			add( sliderTime, BorderLayout.SOUTH );
 		setFocusable( false );
 
-		visibilityAndGrouping = new VisibilityAndGrouping( state );
+		visibilityAndGrouping = new VisibilityAndGrouping( deprecatedState );
 
 		transformListeners = new Listeners.SynchronizedList<>( l -> l.transformChanged( state().getViewerTransform() ) );
 		renderTransformListeners = new Listeners.SynchronizedList<>( l -> {
@@ -377,9 +385,41 @@ public class VolumeViewerPanel
 			}
 		} );
 
-		state.getState().changeListeners().add( this );
+		state.changeListeners().add( this );
 
 		painterThread.start();
+	}
+
+	/**
+	 * Initialize ViewerState with the given {@code sources} and {@code numTimepoints}.
+	 * Set up {@code numGroups} SourceGroups named "group 1", "group 2", etc. Add the
+	 * first source to the first group, the second source to the second group etc.
+	 *
+	 * TODO: Setting up groups like this doesn't make a lot of sense. This just
+	 *   replicates legacy behaviour. The remaining thing that stands in the way of
+	 *   removing it is ViewerState serialization, which assumes that there are always 10
+	 *   groups ... m(
+	 */
+	private static SynchronizedViewerState setupState( final List< SourceAndConverter< ? > > sources, final int numTimepoints, final int numGroups )
+	{
+		final SynchronizedViewerState state = new SynchronizedViewerState( new BasicViewerState() );
+		state.addSources( sources );
+		state.setSourcesActive( sources, true );
+		for ( int i = 0; i < numGroups; ++i ) {
+			final SourceGroup handle = new SourceGroup();
+			state.addGroup( handle );
+			state.setGroupName( handle,  "group " + ( i + 1 ) );
+			state.setGroupActive( handle, true );
+			if ( i < sources.size() )
+				state.addSourceToGroup( sources.get( i ), handle );
+		}
+		state.setNumTimepoints( numTimepoints );
+		state.setInterpolation( NEARESTNEIGHBOR );
+		state.setDisplayMode( SINGLE );
+		state.setCurrentSource( sources.isEmpty() ? null : sources.get( 0 ) );
+		state.setCurrentGroup( numGroups <= 0 ? null : state.getGroups().get( 0 ) );
+
+		return state;
 	}
 
 	/**
@@ -388,8 +428,8 @@ public class VolumeViewerPanel
 	@Deprecated
 	public void addSource( final SourceAndConverter< ? > sourceAndConverter )
 	{
-		state().addSource( sourceAndConverter );
-		state().setSourceActive( sourceAndConverter, true );
+		state.addSource( sourceAndConverter );
+		state.setSourceActive( sourceAndConverter, true );
 	}
 
 	/**
@@ -398,14 +438,14 @@ public class VolumeViewerPanel
 	@Deprecated
 	public void addSources( final Collection< SourceAndConverter< ? > > sourceAndConverter )
 	{
-		state().addSources( sourceAndConverter );
+		state.addSources( sourceAndConverter );
 	}
 
 	// helper for deprecated methods taking Source<?>
 	@Deprecated
 	private SourceAndConverter< ? > soc( final Source< ? > source )
 	{
-		for ( final SourceAndConverter< ? > soc : state().getSources() )
+		for ( final SourceAndConverter< ? > soc : state.getSources() )
 			if ( soc.getSpimSource() == source )
 				return soc;
 		return null;
@@ -417,10 +457,7 @@ public class VolumeViewerPanel
 	@Deprecated
 	public void removeSource( final Source< ? > source )
 	{
-		synchronized ( state() )
-		{
-			state().removeSource( soc( source ) );
-		}
+		state.removeSource( soc( source ) );
 	}
 
 	/**
@@ -429,10 +466,7 @@ public class VolumeViewerPanel
 	@Deprecated
 	public void removeSources( final Collection< Source< ? > > sources )
 	{
-		synchronized ( state() )
-		{
-			state().removeSources( sources.stream().map( this::soc ).collect( Collectors.toList() ) );
-		}
+		state.removeSources( sources.stream().map( this::soc ).collect( Collectors.toList() ) );
 	}
 
 	/**
@@ -441,18 +475,18 @@ public class VolumeViewerPanel
 	@Deprecated
 	public void removeAllSources()
 	{
-		state().clearSources();
+		state.clearSources();
 	}
 
 	/**
 	 * @deprecated Modify {@link #state()} directly
 	 */
 	@Deprecated
-	public void addGroup( final SourceGroup group )
+	public void addGroup( final bdv.viewer.state.SourceGroup group )
 	{
-		synchronized ( state() )
+		synchronized ( state )
 		{
-			state.addGroup( group );
+			deprecatedState.addGroup( group );
 		}
 	}
 
@@ -460,11 +494,11 @@ public class VolumeViewerPanel
 	 * @deprecated Modify {@link #state()} directly
 	 */
 	@Deprecated
-	public void removeGroup( final SourceGroup group )
+	public void removeGroup( final bdv.viewer.state.SourceGroup group )
 	{
-		synchronized ( state() )
+		synchronized ( state )
 		{
-			state.removeGroup( group );
+			deprecatedState.removeGroup( group );
 		}
 	}
 
@@ -478,7 +512,7 @@ public class VolumeViewerPanel
 	public void displayToGlobalCoordinates( final double[] gPos )
 	{
 		assert gPos.length >= 3;
-		state().getViewerTransform().applyInverse( gPos, gPos );
+		state.getViewerTransform().applyInverse( gPos, gPos );
 	}
 
 	/**
@@ -491,7 +525,7 @@ public class VolumeViewerPanel
 	public < P extends RealLocalizable & RealPositionable > void displayToGlobalCoordinates( final P gPos )
 	{
 		assert gPos.numDimensions() >= 3;
-		state().getViewerTransform().applyInverse( gPos, gPos );
+		state.getViewerTransform().applyInverse( gPos, gPos );
 	}
 
 	/**
@@ -507,7 +541,7 @@ public class VolumeViewerPanel
 		final RealPoint lPos = new RealPoint( 3 );
 		lPos.setPosition( x, 0 );
 		lPos.setPosition( y, 1 );
-		state().getViewerTransform().applyInverse( gPos, lPos );
+		state.getViewerTransform().applyInverse( gPos, lPos );
 	}
 
 	@Override
@@ -515,17 +549,15 @@ public class VolumeViewerPanel
 	{
 		display.display();
 
-		synchronized ( this )
+		final AbstractTransformAnimator animator = currentAnimator.get();
+		if ( animator != null )
 		{
-			if ( currentAnimator != null )
-			{
-				final AffineTransform3D transform = currentAnimator.getCurrent( System.currentTimeMillis() );
-				state().setViewerTransform( transform );
-				if ( currentAnimator.isComplete() )
-					currentAnimator = null;
-				else
-					requestRepaint( NONE ); // just to keep animator going. TODO: should really switch to timer-based animations
-			}
+			final AffineTransform3D transform = animator.getCurrent( System.currentTimeMillis() );
+			state.setViewerTransform( transform );
+			if ( animator.isComplete() )
+				currentAnimator.compareAndSet( animator, null );
+			else
+				requestRepaint( NONE ); // just to keep animator going. TODO: should really switch to timer-based animations
 		}
 	}
 
@@ -557,7 +589,7 @@ public class VolumeViewerPanel
 		boolean requiresRepaint = false;
 		if ( Prefs.showMultibox() )
 		{
-			multiBoxOverlayRenderer.setViewerState( state() );
+			multiBoxOverlayRenderer.setViewerState( state );
 			multiBoxOverlayRenderer.updateVirtualScreenSize( display.getWidth(), display.getHeight() );
 			multiBoxOverlayRenderer.paint( ( Graphics2D ) g );
 			requiresRepaint = multiBoxOverlayRenderer.isHighlightInProgress();
@@ -565,22 +597,23 @@ public class VolumeViewerPanel
 
 		if ( Prefs.showTextOverlay() )
 		{
-			sourceInfoOverlayRenderer.setViewerState( state() );
+			final Font font = UIUtils.getFont( "monospaced.small.font" );
+			sourceInfoOverlayRenderer.setViewerState( state );
 			sourceInfoOverlayRenderer.setSourceNameOverlayPosition( Prefs.sourceNameOverlayPosition() );
 			sourceInfoOverlayRenderer.paint( ( Graphics2D ) g );
 
-			final RealPoint gPos = new RealPoint( 3 );
-			getGlobalMouseCoordinates( gPos );
-			final String mousePosGlobalString = String.format( "(%6.1f,%6.1f,%6.1f)", gPos.getDoublePosition( 0 ), gPos.getDoublePosition( 1 ), gPos.getDoublePosition( 2 ) );
+			final double[] gPos = new double[ 3 ];
+			getGlobalMouseCoordinates( RealPoint.wrap( gPos ) );
+			final String mousePosGlobalString = String.format(
+					Locale.ROOT, "%6.1f, %6.1f, %6.1f", gPos[ 0 ], gPos[ 1 ], gPos[ 2 ] );
 
-			g.setFont( new Font( "Monospaced", Font.PLAIN, 12 ) );
-			g.setColor( Color.white );
-			g.drawString( mousePosGlobalString, ( int ) g.getClipBounds().getWidth() - 170, 25 );
+			g.setFont( font );
+			UIUtils.drawString( g, TOP_RIGHT, 1, mousePosGlobalString );
 		}
 
 		if ( Prefs.showScaleBar() )
 		{
-			scaleBarOverlayRenderer.setViewerState( state() );
+			scaleBarOverlayRenderer.setViewerState( state );
 			scaleBarOverlayRenderer.paint( ( Graphics2D ) g );
 		}
 
@@ -605,11 +638,11 @@ public class VolumeViewerPanel
 		switch ( change )
 		{
 		case CURRENT_SOURCE_CHANGED:
-			multiBoxOverlayRenderer.highlight( state().getSources().indexOf( state().getCurrentSource() ) );
+			multiBoxOverlayRenderer.highlight( state.getSources().indexOf( state.getCurrentSource() ) );
 			getDisplayComponent().repaint();
 			break;
 		case DISPLAY_MODE_CHANGED:
-			showMessage( state().getDisplayMode().getName() );
+			showMessage( state.getDisplayMode().getName() );
 			getDisplayComponent().repaint();
 			break;
 		case GROUP_NAME_CHANGED:
@@ -633,7 +666,7 @@ public class VolumeViewerPanel
 //		case INTERPOLATION_CHANGED:
 		case NUM_TIMEPOINTS_CHANGED:
 		{
-			final int numTimepoints = state().getNumTimepoints();
+			final int numTimepoints = state.getNumTimepoints();
 			final int timepoint = Math.max( 0, Math.min( state.getCurrentTimepoint(), numTimepoints - 1 ) );
 			SwingUtilities.invokeLater( () -> {
 				final boolean sliderVisible = Arrays.asList( getComponents() ).contains( sliderTime );
@@ -648,7 +681,7 @@ public class VolumeViewerPanel
 		}
 		case CURRENT_TIMEPOINT_CHANGED:
 		{
-			final int timepoint = state().getCurrentTimepoint();
+			final int timepoint = state.getCurrentTimepoint();
 			SwingUtilities.invokeLater( () -> {
 				blockSliderTimeEvents = true;
 				if ( sliderTime.getValue() != timepoint )
@@ -660,17 +693,17 @@ public class VolumeViewerPanel
 			break;
 		}
 		case VIEWER_TRANSFORM_CHANGED:
-			final AffineTransform3D transform = state().getViewerTransform();
+			final AffineTransform3D transform = state.getViewerTransform();
 			transformListeners.list.forEach( l -> l.transformChanged( transform ) );
 			requestRepaint();
 		}
 	}
 
 	@Override
-	public synchronized void setTransformAnimator( final AbstractTransformAnimator animator )
+	public void setTransformAnimator( final AbstractTransformAnimator animator )
 	{
-		currentAnimator = animator;
-		currentAnimator.setTime( System.currentTimeMillis() );
+		animator.setTime( System.currentTimeMillis() );
+		currentAnimator.set( animator );
 		requestRepaint();
 	}
 
@@ -678,9 +711,9 @@ public class VolumeViewerPanel
 	 * Set the {@link DisplayMode}.
 	 */
 	// TODO: Deprecate or leave as convenience?
-	public synchronized void setDisplayMode( final DisplayMode displayMode )
+	public void setDisplayMode( final DisplayMode displayMode )
 	{
-		state().setDisplayMode( displayMode );
+		state.setDisplayMode( displayMode );
 	}
 
 	/**
@@ -689,7 +722,7 @@ public class VolumeViewerPanel
 	@Deprecated
 	public void setCurrentViewerTransform( final AffineTransform3D viewerTransform )
 	{
-		state().setViewerTransform( viewerTransform );
+		state.setViewerTransform( viewerTransform );
 	}
 
 	/**
@@ -699,27 +732,27 @@ public class VolumeViewerPanel
 	 *            time-point index.
 	 */
 	// TODO: Deprecate or leave as convenience?
-	public synchronized void setTimepoint( final int timepoint )
+	public void setTimepoint( final int timepoint )
 	{
-		state().setCurrentTimepoint( timepoint );
+		state.setCurrentTimepoint( timepoint );
 	}
 
 	/**
 	 * Show the next time-point.
 	 */
 	// TODO: Deprecate or leave as convenience?
-	public synchronized void nextTimePoint()
+	public void nextTimePoint()
 	{
-		NavigationActions.nextTimePoint( state() );
+		NavigationActions.nextTimePoint( state );
 	}
 
 	/**
 	 * Show the previous time-point.
 	 */
 	// TODO: Deprecate or leave as convenience?
-	public synchronized void previousTimePoint()
+	public void previousTimePoint()
 	{
-		NavigationActions.previousTimePoint( state() );
+		NavigationActions.previousTimePoint( state );
 	}
 
 	/**
@@ -735,20 +768,20 @@ public class VolumeViewerPanel
 	 */
 	public void setNumTimepoints( final int numTimepoints )
 	{
-		state().setNumTimepoints( numTimepoints );
+		state.setNumTimepoints( numTimepoints );
 	}
 
 	/**
 	 * @deprecated Use {@link #state()} instead.
 	 *
-	 * Get a copy of the current {@link ViewerState}.
+	 * Get a copy of the current {@link bdv.viewer.state.ViewerState}.
 	 *
-	 * @return a copy of the current {@link ViewerState}.
+	 * @return a copy of the current {@link bdv.viewer.state.ViewerState}.
 	 */
 	@Deprecated
-	public ViewerState getState()
+	public bdv.viewer.state.ViewerState getState()
 	{
-		return state.copy();
+		return deprecatedState.copy();
 	}
 
 	/**
@@ -759,7 +792,7 @@ public class VolumeViewerPanel
 	@Override
 	public SynchronizedViewerState state()
 	{
-		return state.getState();
+		return state;
 	}
 
 	/**
@@ -787,12 +820,6 @@ public class VolumeViewerPanel
 	public TransformEventHandler getTransformEventHandler()
 	{
 		return transformEventHandler;
-	}
-
-	@Override
-	public ConverterSetups getConverterSetups()
-	{
-		return setups;
 	}
 
 	/**
@@ -854,6 +881,12 @@ public class VolumeViewerPanel
 	public Listeners< TimePointListener > timePointListeners()
 	{
 		return timePointListeners;
+	}
+
+	@Override
+	public ConverterSetups getConverterSetups()
+	{
+		return setups;
 	}
 
 	/**
@@ -939,7 +972,6 @@ public class VolumeViewerPanel
 	@SuppressWarnings( "unchecked" )
 	private void setRenderState()
 	{
-		final SynchronizedViewerState state = state();
 		synchronized ( state )
 		{
 			final int currentTimepoint = state.getCurrentTimepoint();
@@ -1024,15 +1056,21 @@ public class VolumeViewerPanel
 		}
 	};
 
-	public synchronized Element stateToXml()
+	public Element stateToXml()
 	{
-		return new XmlIoViewerState().toXml( state );
+		synchronized ( state )
+		{
+			return new XmlIoViewerState().toXml( deprecatedState );
+		}
 	}
 
-	public synchronized void stateFromXml( final Element parent )
+	public void stateFromXml( final Element parent )
 	{
-		final XmlIoViewerState io = new XmlIoViewerState();
-		io.restoreFromXml( parent.getChild( io.getTagName() ), state );
+		synchronized ( state )
+		{
+			final XmlIoViewerState io = new XmlIoViewerState();
+			io.restoreFromXml( parent.getChild( io.getTagName() ), deprecatedState );
+		}
 	}
 
 	/**
@@ -1078,6 +1116,7 @@ public class VolumeViewerPanel
 		{
 			e.printStackTrace();
 		}
-		state.kill();
+		state.clearGroups();
+		state.clearSources();
 	}
 }

--- a/src/main/java/bvv/core/VolumeViewerPanel.java
+++ b/src/main/java/bvv/core/VolumeViewerPanel.java
@@ -78,7 +78,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Collectors;
 import javax.swing.DefaultBoundedRangeModel;
 import javax.swing.JSlider;
@@ -241,7 +240,7 @@ public class VolumeViewerPanel
 	 * calling {@link #requestRepaint()} so listeners have the chance to
 	 * interfere.
 	 */
-	protected final CopyOnWriteArrayList< TimePointListener > timePointListeners;
+	private final Listeners.List< TimePointListener > timePointListeners;
 
 	/**
 	 * Current animator for viewer transform, or null. This is for example used
@@ -360,7 +359,7 @@ public class VolumeViewerPanel
 			if ( renderData != null )
 				l.transformChanged( renderData.getRenderTransformWorldToScreen() );
 		} );
-		timePointListeners = new CopyOnWriteArrayList<>();
+		timePointListeners = new Listeners.SynchronizedList<>( l -> l.timePointChanged( state.getCurrentTimepoint() ) );
 
 		msgOverlay = options.getMsgOverlay();
 
@@ -656,8 +655,7 @@ public class VolumeViewerPanel
 					sliderTime.setValue( timepoint );
 				blockSliderTimeEvents = false;
 			} );
-			for ( final TimePointListener l : timePointListeners )
-				l.timePointChanged( timepoint );
+			timePointListeners.list.forEach( l -> l.timePointChanged( timepoint ) );
 			requestRepaint();
 			break;
 		}
@@ -791,6 +789,7 @@ public class VolumeViewerPanel
 		return transformEventHandler;
 	}
 
+	@Override
 	public ConverterSetups getConverterSetups()
 	{
 		return setups;
@@ -847,50 +846,41 @@ public class VolumeViewerPanel
 	}
 
 	/**
-	 * Add a {@link TimePointListener} to notify about time-point
+	 * Add/remove {@link TimePointListener} to notify about time-point
 	 * changes. Listeners will be notified <em>before</em> calling
-	 * {@link #requestRepaint()} so they have the chance to interfere.
-	 *
-	 * @param listener
-	 *            the listener to add.
+	 * {@link #requestRepaint()} so listeners have the chance to interfere.
 	 */
+	@Override
+	public Listeners< TimePointListener > timePointListeners()
+	{
+		return timePointListeners;
+	}
+
+	/**
+	 * @deprecated Use {@code timePointListeners().add( listener )}.
+	 */
+	@Deprecated
 	public void addTimePointListener( final TimePointListener listener )
 	{
-		addTimePointListener( listener, Integer.MAX_VALUE );
+		timePointListeners().add( listener );
 	}
 
 	/**
-	 * Add a {@link TimePointListener} to notify about time-point
-	 * changes. Listeners will be notified <em>before</em> calling
-	 * {@link #requestRepaint()} so they have the chance to interfere.
-	 *
-	 * @param listener
-	 *            the listener to add.
-	 * @param index
-	 *            position in the list of listeners at which to insert this one.
+	 * @deprecated Use {@code timePointListeners().add( index, listener )}.
 	 */
+	@Deprecated
 	public void addTimePointListener( final TimePointListener listener, final int index )
 	{
-		synchronized ( timePointListeners )
-		{
-			final int s = timePointListeners.size();
-			timePointListeners.add( index < 0 ? 0 : index > s ? s : index, listener );
-			listener.timePointChanged( state.getCurrentTimepoint() );
-		}
+		timePointListeners().add( index, listener );
 	}
 
 	/**
-	 * Remove a {@link TimePointListener}.
-	 *
-	 * @param listener
-	 *            the listener to remove.
+	 * @deprecated Use {@code timePointListeners().remove( listener )}.
 	 */
+	@Deprecated
 	public void removeTimePointListener( final TimePointListener listener )
 	{
-		synchronized ( timePointListeners )
-		{
-			timePointListeners.remove( listener );
-		}
+		timePointListeners().remove( listener );
 	}
 
 	private static int getDitherStep( final int ditherWidth )

--- a/src/main/java/bvv/vistools/BvvHandle.java
+++ b/src/main/java/bvv/vistools/BvvHandle.java
@@ -244,7 +244,7 @@ public abstract class BvvHandle implements Bvv
 
 		if ( timepointListeners != null )
 			for ( final TimePointListener l : timepointListeners )
-				viewer.removeTimePointListener( l );
+				viewer.timePointListeners().remove( l );
 
 		if ( viewerStateChangeListeners != null )
 			viewer.state().changeListeners().removeAll( viewerStateChangeListeners );


### PR DESCRIPTION
  ## Summary

  Companion PR to https://github.com/bigdataviewer/bigvolumeviewer-core/issues/27 ; implements the new `timePointListeners()` abstract method from `AbstractViewerPanel` so that BVV's `VolumeViewerPanel` satisfies the unified interface.

  - Replace `CopyOnWriteArrayList<TimePointListener>` with `Listeners.SynchronizedList` (matches BDV's pattern)
  - Add `timePointListeners()` returning `Listeners<TimePointListener>`
  - Deprecate `addTimePointListener()`/`removeTimePointListener()` as wrappers
  - Add `@Override` on existing `getConverterSetups()`
  - Update `BvvHandle.remove()` to use `viewer.timePointListeners().remove(l)`

  **Requires** bigdataviewer-core with the harmonized `AbstractViewerPanel` (the companion PR above).

  ## Files changed

  - `VolumeViewerPanel.java` — listener refactor + new method + deprecations
  - `BvvHandle.java` — one-line update in `remove()`
