### PR TITLE
Handle generic CacheControl in BVV spimdata loading

### DIFF
--- a/src/main/java/bvv/vistools/BvvFunctions.java
+++ b/src/main/java/bvv/vistools/BvvFunctions.java
@@ -30,6 +30,7 @@ package bvv.vistools;
 
 import bdv.BigDataViewer;
 import bdv.ViewerImgLoader;
+import bdv.cache.CacheControl;
 import bdv.img.cache.VolatileGlobalCellCache;
 import bdv.spimdata.WrapBasicImgLoader;
 import bdv.tools.brightness.ConverterSetup;
@@ -193,9 +194,10 @@ public class BvvFunctions
 		final BvvHandle handle = getHandle( options );
 		final AbstractSequenceDescription< ?, ?, ? > seq = spimData.getSequenceDescription();
 		final int numTimepoints = seq.getTimePoints().size();
-		final VolatileGlobalCellCache cache = ( VolatileGlobalCellCache ) ( ( ViewerImgLoader ) seq.getImgLoader() ).getCacheControl();
+		final CacheControl cache = ( ( ViewerImgLoader ) seq.getImgLoader() ).getCacheControl();
 		handle.getBvvHandle().getCacheControls().addCacheControl( cache );
-		cache.clearCache();
+		if ( cache instanceof VolatileGlobalCellCache )
+			( ( VolatileGlobalCellCache ) cache ).clearCache();
 
 		WrapBasicImgLoader.wrapImgLoaderIfNecessary( spimData );
 		final ArrayList< SourceAndConverter< ? > > sources = new ArrayList<>();


### PR DESCRIPTION
This change removes the assumption that `ViewerImgLoader#getCacheControl()` of `SpimData` always returns a
`VolatileGlobalCellCache`.

Previously, the code performed an unconditional cast in order to register the cache control and clear the cache. This could fail for imgloaders returning a different `CacheControl` implementation.

The updated version:
- works with the generic `CacheControl` interface when registering
  cache controls
- only calls `clearCache()` when the implementation is actually a
  `VolatileGlobalCellCache`

Basically, the same way [it is done in BDV](https://github.com/bigdataviewer/bigdataviewer-core/blob/b64d414cd3bdd7949f72e1c26363738464124fba/src/main/java/bdv/util/BdvFunctions.java#L328).